### PR TITLE
Primitive ops: Use of borrows instead of cloning

### DIFF
--- a/yatima_core/src/eval.rs
+++ b/yatima_core/src/eval.rs
@@ -358,7 +358,7 @@ impl DAG {
             arg.whnf(defs);
             match arg.head {
               DAGPtr::Lit(link) => {
-                let x = unsafe { (*link.as_ptr()).lit.clone() };
+                let x = unsafe { &(*link.as_ptr()).lit };
                 let res = opr.apply1(x);
                 if let Some(res) = res {
                   let top = DAGPtr::App(trail.pop().unwrap());
@@ -381,8 +381,8 @@ impl DAG {
             arg2.whnf(defs);
             match (arg1.head, arg2.head) {
               (DAGPtr::Lit(x_link), DAGPtr::Lit(y_link)) => {
-                let x = unsafe { (*x_link.as_ptr()).lit.clone() };
-                let y = unsafe { (*y_link.as_ptr()).lit.clone() };
+                let x = unsafe { &(*x_link.as_ptr()).lit };
+                let y = unsafe { &(*y_link.as_ptr()).lit };
                 let res = opr.apply2(y, x);
                 if let Some(res) = res {
                   trail.pop();
@@ -412,9 +412,9 @@ impl DAG {
                 DAGPtr::Lit(y_link),
                 DAGPtr::Lit(z_link),
               ) => {
-                let x = unsafe { (*x_link.as_ptr()).lit.clone() };
-                let y = unsafe { (*y_link.as_ptr()).lit.clone() };
-                let z = unsafe { (*z_link.as_ptr()).lit.clone() };
+                let x = unsafe { &(*x_link.as_ptr()).lit };
+                let y = unsafe { &(*y_link.as_ptr()).lit };
+                let z = unsafe { &(*z_link.as_ptr()).lit };
                 let res = opr.apply3(z, y, x);
                 if let Some(res) = res {
                   trail.pop();

--- a/yatima_core/src/literal.rs
+++ b/yatima_core/src/literal.rs
@@ -84,7 +84,7 @@ impl fmt::Display for Literal {
       }
       Bits(x) => {
         if x.len() % 4 == 0 {
-          let (len, mut x) = bits::bits_to_bytes(x.clone());
+          let (len, mut x) = bits::bits_to_bytes(x);
           x.reverse();
           let x: &[u8] = x.as_ref();
           write!(f, "#x{:0>len$}", base::LitBase::Hex.encode(x), len = len / 4)
@@ -217,7 +217,7 @@ impl Literal {
         Ipld::List(vec![Ipld::Integer(1), Ipld::Bytes(x.to_signed_bytes_be())])
       }
       Self::Bits(x) => {
-        let (len, bytes) = bits::bits_to_bytes(x.to_owned());
+        let (len, bytes) = bits::bits_to_bytes(x);
         Ipld::List(vec![
           Ipld::Integer(2),
           Ipld::Integer(len as i128),
@@ -292,7 +292,7 @@ impl Literal {
           Ok(Self::Int(BigInt::from_signed_bytes_be(x)))
         }
         [Ipld::Integer(2), Ipld::Integer(len), Ipld::Bytes(x)] => {
-          let bits = bits::bytes_to_bits(*len as usize, x.to_owned());
+          let bits = bits::bytes_to_bits(*len as usize, x);
           Ok(Self::Bits(bits))
         }
         [Ipld::Integer(3), Ipld::Bytes(x)] => {

--- a/yatima_core/src/parse/literal.rs
+++ b/yatima_core/src/parse/literal.rs
@@ -219,7 +219,7 @@ pub fn parse_bits(from: Span) -> IResult<Span, Literal, ParseError<Span>> {
     match base_x::decode(base.base_digits(), &digits) {
       Ok(mut bytes) => {
         bytes.reverse();
-        let bits = bits::bytes_to_bits(len, bytes);
+        let bits = bits::bytes_to_bits(len, &bytes);
         Ok((i, Literal::Bits(bits)))
       }
       Err(_) => Err(nom::Err::Error(ParseError::new(

--- a/yatima_core/src/prim.rs
+++ b/yatima_core/src/prim.rs
@@ -176,7 +176,7 @@ impl Op {
     }
   }
 
-  pub fn apply1(self, x: Literal) -> Option<Literal> {
+  pub fn apply1(self, x: &Literal) -> Option<Literal> {
     match self {
       Self::Nat(op) => op.apply1(x),
       Self::Int(op) => op.apply1(x),
@@ -198,7 +198,7 @@ impl Op {
     }
   }
 
-  pub fn apply2(self, x: Literal, y: Literal) -> Option<Literal> {
+  pub fn apply2(self, x: &Literal, y: &Literal) -> Option<Literal> {
     match self {
       Self::Nat(op) => op.apply2(x, y),
       Self::Int(op) => op.apply2(x, y),
@@ -220,7 +220,7 @@ impl Op {
     }
   }
 
-  pub fn apply3(self, x: Literal, y: Literal, z: Literal) -> Option<Literal> {
+  pub fn apply3(self, x: &Literal, y: &Literal, z: &Literal) -> Option<Literal> {
     match self {
       Self::Bytes(op) => op.apply3(x, y, z),
       Self::Bits(op) => op.apply3(x, y, z),

--- a/yatima_core/src/prim/bool.rs
+++ b/yatima_core/src/prim/bool.rs
@@ -109,7 +109,7 @@ impl BoolOp {
     }
   }
 
-  pub fn apply1(self, x: Literal) -> Option<Literal> {
+  pub fn apply1(self, x: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x) {
       (Self::Not, Bool(x)) => Some(Bool(!x)),
@@ -117,7 +117,7 @@ impl BoolOp {
     }
   }
 
-  pub fn apply2(self, x: Literal, y: Literal) -> Option<Literal> {
+  pub fn apply2(self, x: &Literal, y: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x, y) {
       (Self::Eql, Bool(x), Bool(y)) => Some(Bool(x == y)),

--- a/yatima_core/src/prim/char.rs
+++ b/yatima_core/src/prim/char.rs
@@ -235,11 +235,11 @@ impl CharOp {
     }
   }
 
-  pub fn apply1(self, x: Literal) -> Option<Literal> {
+  pub fn apply1(self, x: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x) {
-      (Self::FromU32, U32(x)) => char::from_u32(x).map(Char),
-      (Self::ToU32, Char(x)) => Some(U32(x.into())),
+      (Self::FromU32, U32(x)) => char::from_u32(*x).map(Char),
+      (Self::ToU32, Char(x)) => Some(U32((*x).into())),
       (Self::IsAlphabetic, Char(x)) => Some(Bool(x.is_alphabetic())),
       (Self::IsAlphanumeric, Char(x)) => Some(Bool(x.is_alphanumeric())),
       (Self::IsAscii, Char(x)) => Some(Bool(x.is_ascii())),
@@ -276,10 +276,10 @@ impl CharOp {
     }
   }
 
-  pub fn apply2(self, x: Literal, y: Literal) -> Option<Literal> {
+  pub fn apply2(self, x: &Literal, y: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x, y) {
-      (Self::IsDigit, Char(x), U32(y)) => Some(Bool(x.is_digit(y))),
+      (Self::IsDigit, Char(x), U32(y)) => Some(Bool(x.is_digit(*y))),
       _ => None,
     }
   }

--- a/yatima_core/src/prim/i128.rs
+++ b/yatima_core/src/prim/i128.rs
@@ -325,33 +325,33 @@ impl I128Op {
     }
   }
 
-  pub fn apply1(self, x: Literal) -> Option<Literal> {
+  pub fn apply1(self, x: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x) {
       (Self::Abs, I128(x)) => Some(U128(x.unsigned_abs())),
       (Self::Sgn, I128(x)) => Some(Bool(x.is_positive())),
       (Self::CountZeros, I128(x)) => Some(U32(x.count_zeros())),
       (Self::CountOnes, I128(x)) => Some(U32(x.count_ones())),
-      (Self::ToU8, I128(x)) => u8::try_from(x).ok().map(U8),
-      (Self::ToU16, I128(x)) => u16::try_from(x).ok().map(U16),
-      (Self::ToU32, I128(x)) => u32::try_from(x).ok().map(U32),
-      (Self::ToU64, I128(x)) => u64::try_from(x).ok().map(U64),
-      (Self::ToU128, I128(x)) => u128::try_from(x).ok().map(U128),
-      (Self::ToI8, I128(x)) => i8::try_from(x).ok().map(I8),
-      (Self::ToI16, I128(x)) => i16::try_from(x).ok().map(I16),
-      (Self::ToI32, I128(x)) => i32::try_from(x).ok().map(I32),
-      (Self::ToI64, I128(x)) => i64::try_from(x).ok().map(I64),
+      (Self::ToU8, I128(x)) => u8::try_from(*x).ok().map(U8),
+      (Self::ToU16, I128(x)) => u16::try_from(*x).ok().map(U16),
+      (Self::ToU32, I128(x)) => u32::try_from(*x).ok().map(U32),
+      (Self::ToU64, I128(x)) => u64::try_from(*x).ok().map(U64),
+      (Self::ToU128, I128(x)) => u128::try_from(*x).ok().map(U128),
+      (Self::ToI8, I128(x)) => i8::try_from(*x).ok().map(I8),
+      (Self::ToI16, I128(x)) => i16::try_from(*x).ok().map(I16),
+      (Self::ToI32, I128(x)) => i32::try_from(*x).ok().map(I32),
+      (Self::ToI64, I128(x)) => i64::try_from(*x).ok().map(I64),
       (Self::Not, I128(x)) => Some(I128(!x)),
-      (Self::ToInt, I128(x)) => Some(Int(x.into())),
+      (Self::ToInt, I128(x)) => Some(Int((*x).into())),
       (Self::ToBytes, I128(x)) => Some(Bytes(x.to_be_bytes().into())),
       (Self::ToBits, I128(x)) => {
-        Some(Bits(bits::bytes_to_bits(128, x.to_be_bytes().into())))
+        Some(Bits(bits::bytes_to_bits(128, &x.to_be_bytes().into())))
       }
       _ => None,
     }
   }
 
-  pub fn apply2(self, x: Literal, y: Literal) -> Option<Literal> {
+  pub fn apply2(self, x: &Literal, y: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x, y) {
       (Self::Eql, I128(x), I128(y)) => Some(Bool(x == y)),
@@ -362,16 +362,16 @@ impl I128Op {
       (Self::And, I128(x), I128(y)) => Some(I128(x & y)),
       (Self::Or, I128(x), I128(y)) => Some(I128(x | y)),
       (Self::Xor, I128(x), I128(y)) => Some(I128(x ^ y)),
-      (Self::Add, I128(x), I128(y)) => Some(I128(x.wrapping_add(y))),
-      (Self::Sub, I128(x), I128(y)) => Some(I128(x.wrapping_sub(y))),
-      (Self::Mul, I128(x), I128(y)) => Some(I128(x.wrapping_mul(y))),
-      (Self::Div, I128(x), I128(y)) => Some(I128(x.wrapping_div(y))),
-      (Self::Mod, I128(x), I128(y)) => Some(I128(x.wrapping_rem(y))),
-      (Self::Pow, I128(x), U32(y)) => Some(I128(x.wrapping_pow(y))),
-      (Self::Shl, U32(x), I128(y)) => Some(I128(y.wrapping_shl(x))),
-      (Self::Shr, U32(x), I128(y)) => Some(I128(y.wrapping_shr(x))),
-      (Self::Rol, U32(x), I128(y)) => Some(I128(y.rotate_left(x))),
-      (Self::Ror, U32(x), I128(y)) => Some(I128(y.rotate_right(x))),
+      (Self::Add, I128(x), I128(y)) => Some(I128(x.wrapping_add(*y))),
+      (Self::Sub, I128(x), I128(y)) => Some(I128(x.wrapping_sub(*y))),
+      (Self::Mul, I128(x), I128(y)) => Some(I128(x.wrapping_mul(*y))),
+      (Self::Div, I128(x), I128(y)) => Some(I128(x.wrapping_div(*y))),
+      (Self::Mod, I128(x), I128(y)) => Some(I128(x.wrapping_rem(*y))),
+      (Self::Pow, I128(x), U32(y)) => Some(I128(x.wrapping_pow(*y))),
+      (Self::Shl, U32(x), I128(y)) => Some(I128(y.wrapping_shl(*x))),
+      (Self::Shr, U32(x), I128(y)) => Some(I128(y.wrapping_shr(*x))),
+      (Self::Rol, U32(x), I128(y)) => Some(I128(y.rotate_left(*x))),
+      (Self::Ror, U32(x), I128(y)) => Some(I128(y.rotate_right(*x))),
       _ => None,
     }
   }

--- a/yatima_core/src/prim/i16.rs
+++ b/yatima_core/src/prim/i16.rs
@@ -325,33 +325,33 @@ impl I16Op {
     }
   }
 
-  pub fn apply1(self, x: Literal) -> Option<Literal> {
+  pub fn apply1(self, x: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x) {
       (Self::Abs, I16(x)) => Some(U16(x.unsigned_abs())),
       (Self::Sgn, I16(x)) => Some(Bool(x.is_positive())),
       (Self::CountZeros, I16(x)) => Some(U32(x.count_zeros())),
       (Self::CountOnes, I16(x)) => Some(U32(x.count_ones())),
-      (Self::ToU8, I16(x)) => u8::try_from(x).ok().map(U8),
-      (Self::ToU16, I16(x)) => u16::try_from(x).ok().map(U16),
-      (Self::ToU32, I16(x)) => u32::try_from(x).ok().map(U32),
-      (Self::ToU64, I16(x)) => u64::try_from(x).ok().map(U64),
-      (Self::ToU128, I16(x)) => u128::try_from(x).ok().map(U128),
-      (Self::ToI8, I16(x)) => i8::try_from(x).ok().map(I8),
-      (Self::ToI32, I16(x)) => Some(I32(x.into())),
-      (Self::ToI64, I16(x)) => Some(I64(x.into())),
-      (Self::ToI128, I16(x)) => Some(I128(x.into())),
+      (Self::ToU8, I16(x)) => u8::try_from(*x).ok().map(U8),
+      (Self::ToU16, I16(x)) => u16::try_from(*x).ok().map(U16),
+      (Self::ToU32, I16(x)) => u32::try_from(*x).ok().map(U32),
+      (Self::ToU64, I16(x)) => u64::try_from(*x).ok().map(U64),
+      (Self::ToU128, I16(x)) => u128::try_from(*x).ok().map(U128),
+      (Self::ToI8, I16(x)) => i8::try_from(*x).ok().map(I8),
+      (Self::ToI32, I16(x)) => Some(I32((*x).into())),
+      (Self::ToI64, I16(x)) => Some(I64((*x).into())),
+      (Self::ToI128, I16(x)) => Some(I128((*x).into())),
       (Self::Not, I16(x)) => Some(I16(!x)),
-      (Self::ToInt, I16(x)) => Some(Int(x.into())),
+      (Self::ToInt, I16(x)) => Some(Int((*x).into())),
       (Self::ToBytes, I16(x)) => Some(Bytes(x.to_be_bytes().into())),
       (Self::ToBits, I16(x)) => {
-        Some(Bits(bits::bytes_to_bits(16, x.to_be_bytes().into())))
+        Some(Bits(bits::bytes_to_bits(16, &x.to_be_bytes().into())))
       }
       _ => None,
     }
   }
 
-  pub fn apply2(self, x: Literal, y: Literal) -> Option<Literal> {
+  pub fn apply2(self, x: &Literal, y: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x, y) {
       (Self::Eql, I16(x), I16(y)) => Some(Bool(x == y)),
@@ -362,16 +362,16 @@ impl I16Op {
       (Self::And, I16(x), I16(y)) => Some(I16(x & y)),
       (Self::Or, I16(x), I16(y)) => Some(I16(x | y)),
       (Self::Xor, I16(x), I16(y)) => Some(I16(x ^ y)),
-      (Self::Add, I16(x), I16(y)) => Some(I16(x.wrapping_add(y))),
-      (Self::Sub, I16(x), I16(y)) => Some(I16(x.wrapping_sub(y))),
-      (Self::Mul, I16(x), I16(y)) => Some(I16(x.wrapping_mul(y))),
-      (Self::Div, I16(x), I16(y)) => Some(I16(x.wrapping_div(y))),
-      (Self::Mod, I16(x), I16(y)) => Some(I16(x.wrapping_rem(y))),
-      (Self::Pow, I16(x), U32(y)) => Some(I16(x.wrapping_pow(y))),
-      (Self::Shl, U32(x), I16(y)) => Some(I16(y.wrapping_shl(x))),
-      (Self::Shr, U32(x), I16(y)) => Some(I16(y.wrapping_shr(x))),
-      (Self::Rol, U32(x), I16(y)) => Some(I16(y.rotate_left(x))),
-      (Self::Ror, U32(x), I16(y)) => Some(I16(y.rotate_right(x))),
+      (Self::Add, I16(x), I16(y)) => Some(I16(x.wrapping_add(*y))),
+      (Self::Sub, I16(x), I16(y)) => Some(I16(x.wrapping_sub(*y))),
+      (Self::Mul, I16(x), I16(y)) => Some(I16(x.wrapping_mul(*y))),
+      (Self::Div, I16(x), I16(y)) => Some(I16(x.wrapping_div(*y))),
+      (Self::Mod, I16(x), I16(y)) => Some(I16(x.wrapping_rem(*y))),
+      (Self::Pow, I16(x), U32(y)) => Some(I16(x.wrapping_pow(*y))),
+      (Self::Shl, U32(x), I16(y)) => Some(I16(y.wrapping_shl(*x))),
+      (Self::Shr, U32(x), I16(y)) => Some(I16(y.wrapping_shr(*x))),
+      (Self::Rol, U32(x), I16(y)) => Some(I16(y.rotate_left(*x))),
+      (Self::Ror, U32(x), I16(y)) => Some(I16(y.rotate_right(*x))),
       _ => None,
     }
   }

--- a/yatima_core/src/prim/i32.rs
+++ b/yatima_core/src/prim/i32.rs
@@ -325,33 +325,33 @@ impl I32Op {
     }
   }
 
-  pub fn apply1(self, x: Literal) -> Option<Literal> {
+  pub fn apply1(self, x: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x) {
       (Self::Abs, I32(x)) => Some(U32(x.unsigned_abs())),
       (Self::Sgn, I32(x)) => Some(Bool(x.is_positive())),
       (Self::CountZeros, I32(x)) => Some(U32(x.count_zeros())),
       (Self::CountOnes, I32(x)) => Some(U32(x.count_ones())),
-      (Self::ToU8, I32(x)) => u8::try_from(x).ok().map(U8),
-      (Self::ToU16, I32(x)) => u16::try_from(x).ok().map(U16),
-      (Self::ToU32, I32(x)) => u32::try_from(x).ok().map(U32),
-      (Self::ToU64, I32(x)) => u64::try_from(x).ok().map(U64),
-      (Self::ToU128, I32(x)) => u128::try_from(x).ok().map(U128),
-      (Self::ToI8, I32(x)) => i8::try_from(x).ok().map(I8),
-      (Self::ToI16, I32(x)) => i16::try_from(x).ok().map(I16),
-      (Self::ToI64, I32(x)) => Some(I64(x.into())),
-      (Self::ToI128, I32(x)) => Some(I128(x.into())),
+      (Self::ToU8, I32(x)) => u8::try_from(*x).ok().map(U8),
+      (Self::ToU16, I32(x)) => u16::try_from(*x).ok().map(U16),
+      (Self::ToU32, I32(x)) => u32::try_from(*x).ok().map(U32),
+      (Self::ToU64, I32(x)) => u64::try_from(*x).ok().map(U64),
+      (Self::ToU128, I32(x)) => u128::try_from(*x).ok().map(U128),
+      (Self::ToI8, I32(x)) => i8::try_from(*x).ok().map(I8),
+      (Self::ToI16, I32(x)) => i16::try_from(*x).ok().map(I16),
+      (Self::ToI64, I32(x)) => Some(I64((*x).into())),
+      (Self::ToI128, I32(x)) => Some(I128((*x).into())),
       (Self::Not, I32(x)) => Some(I32(!x)),
-      (Self::ToInt, I32(x)) => Some(Int(x.into())),
+      (Self::ToInt, I32(x)) => Some(Int((*x).into())),
       (Self::ToBytes, I32(x)) => Some(Bytes(x.to_be_bytes().into())),
       (Self::ToBits, I32(x)) => {
-        Some(Bits(bits::bytes_to_bits(32, x.to_be_bytes().into())))
+        Some(Bits(bits::bytes_to_bits(32, &x.to_be_bytes().into())))
       }
       _ => None,
     }
   }
 
-  pub fn apply2(self, x: Literal, y: Literal) -> Option<Literal> {
+  pub fn apply2(self, x: &Literal, y: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x, y) {
       (Self::Eql, I32(x), I32(y)) => Some(Bool(x == y)),
@@ -362,16 +362,16 @@ impl I32Op {
       (Self::And, I32(x), I32(y)) => Some(I32(x & y)),
       (Self::Or, I32(x), I32(y)) => Some(I32(x | y)),
       (Self::Xor, I32(x), I32(y)) => Some(I32(x ^ y)),
-      (Self::Add, I32(x), I32(y)) => Some(I32(x.wrapping_add(y))),
-      (Self::Sub, I32(x), I32(y)) => Some(I32(x.wrapping_sub(y))),
-      (Self::Mul, I32(x), I32(y)) => Some(I32(x.wrapping_mul(y))),
-      (Self::Div, I32(x), I32(y)) => Some(I32(x.wrapping_div(y))),
-      (Self::Mod, I32(x), I32(y)) => Some(I32(x.wrapping_rem(y))),
-      (Self::Pow, I32(x), U32(y)) => Some(I32(x.wrapping_pow(y))),
-      (Self::Shl, U32(x), I32(y)) => Some(I32(y.wrapping_shl(x))),
-      (Self::Shr, U32(x), I32(y)) => Some(I32(y.wrapping_shr(x))),
-      (Self::Rol, U32(x), I32(y)) => Some(I32(y.rotate_left(x))),
-      (Self::Ror, U32(x), I32(y)) => Some(I32(y.rotate_right(x))),
+      (Self::Add, I32(x), I32(y)) => Some(I32(x.wrapping_add(*y))),
+      (Self::Sub, I32(x), I32(y)) => Some(I32(x.wrapping_sub(*y))),
+      (Self::Mul, I32(x), I32(y)) => Some(I32(x.wrapping_mul(*y))),
+      (Self::Div, I32(x), I32(y)) => Some(I32(x.wrapping_div(*y))),
+      (Self::Mod, I32(x), I32(y)) => Some(I32(x.wrapping_rem(*y))),
+      (Self::Pow, I32(x), U32(y)) => Some(I32(x.wrapping_pow(*y))),
+      (Self::Shl, U32(x), I32(y)) => Some(I32(y.wrapping_shl(*x))),
+      (Self::Shr, U32(x), I32(y)) => Some(I32(y.wrapping_shr(*x))),
+      (Self::Rol, U32(x), I32(y)) => Some(I32(y.rotate_left(*x))),
+      (Self::Ror, U32(x), I32(y)) => Some(I32(y.rotate_right(*x))),
       _ => None,
     }
   }

--- a/yatima_core/src/prim/i64.rs
+++ b/yatima_core/src/prim/i64.rs
@@ -325,33 +325,33 @@ impl I64Op {
     }
   }
 
-  pub fn apply1(self, x: Literal) -> Option<Literal> {
+  pub fn apply1(self, x: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x) {
       (Self::Abs, I64(x)) => Some(U64(x.unsigned_abs())),
       (Self::Sgn, I64(x)) => Some(Bool(x.is_positive())),
       (Self::CountZeros, I64(x)) => Some(U32(x.count_zeros())),
       (Self::CountOnes, I64(x)) => Some(U32(x.count_ones())),
-      (Self::ToU8, I64(x)) => u8::try_from(x).ok().map(U8),
-      (Self::ToU16, I64(x)) => u16::try_from(x).ok().map(U16),
-      (Self::ToU32, I64(x)) => u32::try_from(x).ok().map(U32),
-      (Self::ToU64, I64(x)) => u64::try_from(x).ok().map(U64),
-      (Self::ToU128, I64(x)) => u128::try_from(x).ok().map(U128),
-      (Self::ToI8, I64(x)) => i8::try_from(x).ok().map(I8),
-      (Self::ToI16, I64(x)) => i16::try_from(x).ok().map(I16),
-      (Self::ToI32, I64(x)) => i32::try_from(x).ok().map(I32),
-      (Self::ToI128, I64(x)) => Some(I128(x.into())),
+      (Self::ToU8, I64(x)) => u8::try_from(*x).ok().map(U8),
+      (Self::ToU16, I64(x)) => u16::try_from(*x).ok().map(U16),
+      (Self::ToU32, I64(x)) => u32::try_from(*x).ok().map(U32),
+      (Self::ToU64, I64(x)) => u64::try_from(*x).ok().map(U64),
+      (Self::ToU128, I64(x)) => u128::try_from(*x).ok().map(U128),
+      (Self::ToI8, I64(x)) => i8::try_from(*x).ok().map(I8),
+      (Self::ToI16, I64(x)) => i16::try_from(*x).ok().map(I16),
+      (Self::ToI32, I64(x)) => i32::try_from(*x).ok().map(I32),
+      (Self::ToI128, I64(x)) => Some(I128((*x).into())),
       (Self::Not, I64(x)) => Some(I64(!x)),
-      (Self::ToInt, I64(x)) => Some(Int(x.into())),
+      (Self::ToInt, I64(x)) => Some(Int((*x).into())),
       (Self::ToBytes, I64(x)) => Some(Bytes(x.to_be_bytes().into())),
       (Self::ToBits, I64(x)) => {
-        Some(Bits(bits::bytes_to_bits(64, x.to_be_bytes().into())))
+        Some(Bits(bits::bytes_to_bits(64, &x.to_be_bytes().into())))
       }
       _ => None,
     }
   }
 
-  pub fn apply2(self, x: Literal, y: Literal) -> Option<Literal> {
+  pub fn apply2(self, x: &Literal, y: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x, y) {
       (Self::Eql, I64(x), I64(y)) => Some(Bool(x == y)),
@@ -362,16 +362,16 @@ impl I64Op {
       (Self::And, I64(x), I64(y)) => Some(I64(x & y)),
       (Self::Or, I64(x), I64(y)) => Some(I64(x | y)),
       (Self::Xor, I64(x), I64(y)) => Some(I64(x ^ y)),
-      (Self::Add, I64(x), I64(y)) => Some(I64(x.wrapping_add(y))),
-      (Self::Sub, I64(x), I64(y)) => Some(I64(x.wrapping_sub(y))),
-      (Self::Mul, I64(x), I64(y)) => Some(I64(x.wrapping_mul(y))),
-      (Self::Div, I64(x), I64(y)) => Some(I64(x.wrapping_div(y))),
-      (Self::Mod, I64(x), I64(y)) => Some(I64(x.wrapping_rem(y))),
-      (Self::Pow, I64(x), U32(y)) => Some(I64(x.wrapping_pow(y))),
-      (Self::Shl, U32(x), I64(y)) => Some(I64(y.wrapping_shl(x))),
-      (Self::Shr, U32(x), I64(y)) => Some(I64(y.wrapping_shr(x))),
-      (Self::Rol, U32(x), I64(y)) => Some(I64(y.rotate_left(x))),
-      (Self::Ror, U32(x), I64(y)) => Some(I64(y.rotate_right(x))),
+      (Self::Add, I64(x), I64(y)) => Some(I64(x.wrapping_add(*y))),
+      (Self::Sub, I64(x), I64(y)) => Some(I64(x.wrapping_sub(*y))),
+      (Self::Mul, I64(x), I64(y)) => Some(I64(x.wrapping_mul(*y))),
+      (Self::Div, I64(x), I64(y)) => Some(I64(x.wrapping_div(*y))),
+      (Self::Mod, I64(x), I64(y)) => Some(I64(x.wrapping_rem(*y))),
+      (Self::Pow, I64(x), U32(y)) => Some(I64(x.wrapping_pow(*y))),
+      (Self::Shl, U32(x), I64(y)) => Some(I64(y.wrapping_shl(*x))),
+      (Self::Shr, U32(x), I64(y)) => Some(I64(y.wrapping_shr(*x))),
+      (Self::Rol, U32(x), I64(y)) => Some(I64(y.rotate_left(*x))),
+      (Self::Ror, U32(x), I64(y)) => Some(I64(y.rotate_right(*x))),
       _ => None,
     }
   }

--- a/yatima_core/src/prim/i8.rs
+++ b/yatima_core/src/prim/i8.rs
@@ -325,33 +325,33 @@ impl I8Op {
     }
   }
 
-  pub fn apply1(self, x: Literal) -> Option<Literal> {
+  pub fn apply1(self, x: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x) {
       (Self::Abs, I8(x)) => Some(U8(x.unsigned_abs())),
       (Self::Sgn, I8(x)) => Some(Bool(x.is_positive())),
       (Self::CountZeros, I8(x)) => Some(U32(x.count_zeros())),
       (Self::CountOnes, I8(x)) => Some(U32(x.count_ones())),
-      (Self::ToU8, I8(x)) => u8::try_from(x).ok().map(U8),
-      (Self::ToU16, I8(x)) => u16::try_from(x).ok().map(U16),
-      (Self::ToU32, I8(x)) => u32::try_from(x).ok().map(U32),
-      (Self::ToU64, I8(x)) => u64::try_from(x).ok().map(U64),
-      (Self::ToU128, I8(x)) => u128::try_from(x).ok().map(U128),
-      (Self::ToI16, I8(x)) => Some(I16(x.into())),
-      (Self::ToI32, I8(x)) => Some(I32(x.into())),
-      (Self::ToI64, I8(x)) => Some(I64(x.into())),
-      (Self::ToI128, I8(x)) => Some(I128(x.into())),
+      (Self::ToU8, I8(x)) => u8::try_from(*x).ok().map(U8),
+      (Self::ToU16, I8(x)) => u16::try_from(*x).ok().map(U16),
+      (Self::ToU32, I8(x)) => u32::try_from(*x).ok().map(U32),
+      (Self::ToU64, I8(x)) => u64::try_from(*x).ok().map(U64),
+      (Self::ToU128, I8(x)) => u128::try_from(*x).ok().map(U128),
+      (Self::ToI16, I8(x)) => Some(I16((*x).into())),
+      (Self::ToI32, I8(x)) => Some(I32((*x).into())),
+      (Self::ToI64, I8(x)) => Some(I64((*x).into())),
+      (Self::ToI128, I8(x)) => Some(I128((*x).into())),
       (Self::Not, I8(x)) => Some(I8(!x)),
-      (Self::ToInt, I8(x)) => Some(Int(x.into())),
+      (Self::ToInt, I8(x)) => Some(Int((*x).into())),
       (Self::ToBytes, I8(x)) => Some(Bytes(x.to_be_bytes().into())),
       (Self::ToBits, I8(x)) => {
-        Some(Bits(bits::bytes_to_bits(8, x.to_be_bytes().into())))
+        Some(Bits(bits::bytes_to_bits(8, &x.to_be_bytes().into())))
       }
       _ => None,
     }
   }
 
-  pub fn apply2(self, x: Literal, y: Literal) -> Option<Literal> {
+  pub fn apply2(self, x: &Literal, y: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x, y) {
       (Self::Eql, I8(x), I8(y)) => Some(Bool(x == y)),
@@ -362,16 +362,16 @@ impl I8Op {
       (Self::And, I8(x), I8(y)) => Some(I8(x & y)),
       (Self::Or, I8(x), I8(y)) => Some(I8(x | y)),
       (Self::Xor, I8(x), I8(y)) => Some(I8(x ^ y)),
-      (Self::Add, I8(x), I8(y)) => Some(I8(x.wrapping_add(y))),
-      (Self::Sub, I8(x), I8(y)) => Some(I8(x.wrapping_sub(y))),
-      (Self::Mul, I8(x), I8(y)) => Some(I8(x.wrapping_mul(y))),
-      (Self::Div, I8(x), I8(y)) => Some(I8(x.wrapping_div(y))),
-      (Self::Mod, I8(x), I8(y)) => Some(I8(x.wrapping_rem(y))),
-      (Self::Pow, I8(x), U32(y)) => Some(I8(x.wrapping_pow(y))),
-      (Self::Shl, U32(x), I8(y)) => Some(I8(y.wrapping_shl(x))),
-      (Self::Shr, U32(x), I8(y)) => Some(I8(y.wrapping_shr(x))),
-      (Self::Rol, U32(x), I8(y)) => Some(I8(y.rotate_left(x))),
-      (Self::Ror, U32(x), I8(y)) => Some(I8(y.rotate_right(x))),
+      (Self::Add, I8(x), I8(y)) => Some(I8(x.wrapping_add(*y))),
+      (Self::Sub, I8(x), I8(y)) => Some(I8(x.wrapping_sub(*y))),
+      (Self::Mul, I8(x), I8(y)) => Some(I8(x.wrapping_mul(*y))),
+      (Self::Div, I8(x), I8(y)) => Some(I8(x.wrapping_div(*y))),
+      (Self::Mod, I8(x), I8(y)) => Some(I8(x.wrapping_rem(*y))),
+      (Self::Pow, I8(x), U32(y)) => Some(I8(x.wrapping_pow(*y))),
+      (Self::Shl, U32(x), I8(y)) => Some(I8(y.wrapping_shl(*x))),
+      (Self::Shr, U32(x), I8(y)) => Some(I8(y.wrapping_shr(*x))),
+      (Self::Rol, U32(x), I8(y)) => Some(I8(y.rotate_left(*x))),
+      (Self::Ror, U32(x), I8(y)) => Some(I8(y.rotate_right(*x))),
       _ => None,
     }
   }

--- a/yatima_core/src/prim/int.rs
+++ b/yatima_core/src/prim/int.rs
@@ -141,7 +141,7 @@ impl IntOp {
     }
   }
 
-  pub fn apply1(self, x: Literal) -> Option<Literal> {
+  pub fn apply1(self, x: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x) {
       (Self::Sgn, Int(x)) => match x.sign() {
@@ -149,12 +149,12 @@ impl IntOp {
         Sign::Plus => Some(Int(BigInt::from(1i64))),
         Sign::Minus => Some(Int(BigInt::from(-1i64))),
       },
-      (Self::Abs, Int(x)) => Some(Nat(x.into_parts().1)),
+      (Self::Abs, Int(x)) => Some(Nat(x.clone().into_parts().1)),
       _ => None,
     }
   }
 
-  pub fn apply2(self, x: Literal, y: Literal) -> Option<Literal> {
+  pub fn apply2(self, x: &Literal, y: &Literal) -> Option<Literal> {
     use Literal::*;
     let tt = Bool(true);
     let ff = Bool(false);
@@ -167,8 +167,8 @@ impl IntOp {
       (Self::Add, Int(x), Int(y)) => Some(Int(x + y)),
       (Self::Sub, Int(x), Int(y)) => Some(Int(x - y)),
       (Self::Mul, Int(x), Int(y)) => Some(Int(x * y)),
-      (Self::Div, Int(x), Int(y)) if y != 0.into() => Some(Int(x / y)),
-      (Self::Mod, Int(x), Int(y)) if y != 0.into() => Some(Int(x % y)),
+      (Self::Div, Int(x), Int(y)) if *y != 0.into() => Some(Int(x / y)),
+      (Self::Mod, Int(x), Int(y)) if *y != 0.into() => Some(Int(x % y)),
       _ => None,
     }
   }

--- a/yatima_core/src/prim/nat.rs
+++ b/yatima_core/src/prim/nat.rs
@@ -131,12 +131,12 @@ impl NatOp {
     }
   }
 
-  pub fn apply1(self, x: Literal) -> Option<Literal> {
+  pub fn apply1(self, x: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x) {
       (Self::Suc, Nat(x)) => Some(Nat(x + BigUint::from(1u64))),
       (Self::Pre, Nat(x)) => {
-        if x != 0u64.into() {
+        if *x != 0u64.into() {
           Some(Nat(x - BigUint::from(1u64)))
         }
         else {
@@ -147,7 +147,7 @@ impl NatOp {
     }
   }
 
-  pub fn apply2(self, x: Literal, y: Literal) -> Option<Literal> {
+  pub fn apply2(self, x: &Literal, y: &Literal) -> Option<Literal> {
     use Literal::*;
     let tt = Bool(true);
     let ff = Bool(false);
@@ -160,8 +160,8 @@ impl NatOp {
       (Self::Add, Nat(x), Nat(y)) => Some(Nat(x + y)),
       (Self::Sub, Nat(x), Nat(y)) if x >= y => Some(Nat(x - y)),
       (Self::Mul, Nat(x), Nat(y)) => Some(Nat(x * y)),
-      (Self::Div, Nat(x), Nat(y)) if y != (0u64).into() => Some(Nat(x / y)),
-      (Self::Mod, Nat(x), Nat(y)) if y != (0u64).into() => Some(Nat(x % y)),
+      (Self::Div, Nat(x), Nat(y)) if *y != (0u64).into() => Some(Nat(x / y)),
+      (Self::Mod, Nat(x), Nat(y)) if *y != (0u64).into() => Some(Nat(x % y)),
       _ => None,
     }
   }

--- a/yatima_core/src/prim/u128.rs
+++ b/yatima_core/src/prim/u128.rs
@@ -311,31 +311,31 @@ impl U128Op {
     }
   }
 
-  pub fn apply1(self, x: Literal) -> Option<Literal> {
+  pub fn apply1(self, x: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x) {
       (Self::CountZeros, U64(x)) => Some(U32(x.count_zeros())),
       (Self::CountOnes, U64(x)) => Some(U32(x.count_ones())),
-      (Self::ToU8, U64(x)) => u8::try_from(x).ok().map(U8),
-      (Self::ToU16, U64(x)) => u16::try_from(x).ok().map(U16),
-      (Self::ToU32, U64(x)) => u32::try_from(x).ok().map(U32),
-      (Self::ToU64, U64(x)) => u64::try_from(x).ok().map(U64),
-      (Self::ToI8, U64(x)) => i8::try_from(x).ok().map(I8),
-      (Self::ToI16, U64(x)) => i16::try_from(x).ok().map(I16),
-      (Self::ToI32, U64(x)) => i32::try_from(x).ok().map(I32),
-      (Self::ToI64, U64(x)) => i64::try_from(x).ok().map(I64),
-      (Self::ToI128, U64(x)) => Some(I128(x.into())),
+      (Self::ToU8, U64(x)) => u8::try_from(*x).ok().map(U8),
+      (Self::ToU16, U64(x)) => u16::try_from(*x).ok().map(U16),
+      (Self::ToU32, U64(x)) => u32::try_from(*x).ok().map(U32),
+      (Self::ToU64, U64(x)) => u64::try_from(*x).ok().map(U64),
+      (Self::ToI8, U64(x)) => i8::try_from(*x).ok().map(I8),
+      (Self::ToI16, U64(x)) => i16::try_from(*x).ok().map(I16),
+      (Self::ToI32, U64(x)) => i32::try_from(*x).ok().map(I32),
+      (Self::ToI64, U64(x)) => i64::try_from(*x).ok().map(I64),
+      (Self::ToI128, U64(x)) => Some(I128((*x).into())),
       (Self::Not, U64(x)) => Some(U64(!x)),
-      (Self::ToInt, U64(x)) => Some(Int(x.into())),
+      (Self::ToInt, U64(x)) => Some(Int((*x).into())),
       (Self::ToBytes, U64(x)) => Some(Bytes(x.to_be_bytes().into())),
       (Self::ToBits, U128(x)) => {
-        Some(Bits(bits::bytes_to_bits(128, x.to_be_bytes().into())))
+        Some(Bits(bits::bytes_to_bits(128, &x.to_be_bytes().into())))
       }
       _ => None,
     }
   }
 
-  pub fn apply2(self, x: Literal, y: Literal) -> Option<Literal> {
+  pub fn apply2(self, x: &Literal, y: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x, y) {
       (Self::Eql, U32(x), U32(y)) => Some(Bool(x == y)),
@@ -346,16 +346,16 @@ impl U128Op {
       (Self::And, U128(x), U128(y)) => Some(U128(x & y)),
       (Self::Or, U128(x), U128(y)) => Some(U128(x | y)),
       (Self::Xor, U128(x), U128(y)) => Some(U128(x ^ y)),
-      (Self::Add, U128(x), U128(y)) => Some(U128(x.wrapping_add(y))),
-      (Self::Sub, U128(x), U128(y)) => Some(U128(x.wrapping_sub(y))),
-      (Self::Mul, U128(x), U128(y)) => Some(U128(x.wrapping_mul(y))),
-      (Self::Div, U128(x), U128(y)) => Some(U128(x.wrapping_div(y))),
-      (Self::Mod, U128(x), U128(y)) => Some(U128(x.wrapping_rem(y))),
-      (Self::Pow, U128(x), U32(y)) => Some(U128(x.wrapping_pow(y))),
-      (Self::Shl, U32(x), U128(y)) => Some(U128(y.wrapping_shl(x))),
-      (Self::Shr, U32(x), U128(y)) => Some(U128(y.wrapping_shr(x))),
-      (Self::Rol, U32(x), U128(y)) => Some(U128(y.rotate_left(x))),
-      (Self::Ror, U32(x), U128(y)) => Some(U128(y.rotate_right(x))),
+      (Self::Add, U128(x), U128(y)) => Some(U128(x.wrapping_add(*y))),
+      (Self::Sub, U128(x), U128(y)) => Some(U128(x.wrapping_sub(*y))),
+      (Self::Mul, U128(x), U128(y)) => Some(U128(x.wrapping_mul(*y))),
+      (Self::Div, U128(x), U128(y)) => Some(U128(x.wrapping_div(*y))),
+      (Self::Mod, U128(x), U128(y)) => Some(U128(x.wrapping_rem(*y))),
+      (Self::Pow, U128(x), U32(y)) => Some(U128(x.wrapping_pow(*y))),
+      (Self::Shl, U32(x), U128(y)) => Some(U128(y.wrapping_shl(*x))),
+      (Self::Shr, U32(x), U128(y)) => Some(U128(y.wrapping_shr(*x))),
+      (Self::Rol, U32(x), U128(y)) => Some(U128(y.rotate_left(*x))),
+      (Self::Ror, U32(x), U128(y)) => Some(U128(y.rotate_right(*x))),
       _ => None,
     }
   }

--- a/yatima_core/src/prim/u16.rs
+++ b/yatima_core/src/prim/u16.rs
@@ -311,31 +311,31 @@ impl U16Op {
     }
   }
 
-  pub fn apply1(self, x: Literal) -> Option<Literal> {
+  pub fn apply1(self, x: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x) {
       (Self::CountZeros, U16(x)) => Some(U32(x.count_zeros())),
       (Self::CountOnes, U16(x)) => Some(U32(x.count_ones())),
-      (Self::ToU8, U16(x)) => u16::try_from(x).ok().map(U16),
-      (Self::ToU32, U16(x)) => Some(U32(x.into())),
-      (Self::ToU64, U16(x)) => Some(U64(x.into())),
-      (Self::ToU128, U16(x)) => Some(U128(x.into())),
-      (Self::ToI8, U16(x)) => i8::try_from(x).ok().map(I8),
-      (Self::ToI16, U16(x)) => i16::try_from(x).ok().map(I16),
-      (Self::ToI32, U16(x)) => Some(I32(x.into())),
-      (Self::ToI64, U16(x)) => Some(I64(x.into())),
-      (Self::ToI128, U16(x)) => Some(I128(x.into())),
+      (Self::ToU8, U16(x)) => u16::try_from(*x).ok().map(U16),
+      (Self::ToU32, U16(x)) => Some(U32((*x).into())),
+      (Self::ToU64, U16(x)) => Some(U64((*x).into())),
+      (Self::ToU128, U16(x)) => Some(U128((*x).into())),
+      (Self::ToI8, U16(x)) => i8::try_from(*x).ok().map(I8),
+      (Self::ToI16, U16(x)) => i16::try_from(*x).ok().map(I16),
+      (Self::ToI32, U16(x)) => Some(I32((*x).into())),
+      (Self::ToI64, U16(x)) => Some(I64((*x).into())),
+      (Self::ToI128, U16(x)) => Some(I128((*x).into())),
       (Self::Not, U16(x)) => Some(U16(!x)),
-      (Self::ToInt, U16(x)) => Some(Int(x.into())),
+      (Self::ToInt, U16(x)) => Some(Int((*x).into())),
       (Self::ToBytes, U16(x)) => Some(Bytes(x.to_be_bytes().into())),
       (Self::ToBits, U16(x)) => {
-        Some(Bits(bits::bytes_to_bits(16, x.to_be_bytes().into())))
+        Some(Bits(bits::bytes_to_bits(16, &x.to_be_bytes().into())))
       }
       _ => None,
     }
   }
 
-  pub fn apply2(self, x: Literal, y: Literal) -> Option<Literal> {
+  pub fn apply2(self, x: &Literal, y: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x, y) {
       (Self::Eql, U16(x), U16(y)) => Some(Bool(x == y)),
@@ -346,16 +346,16 @@ impl U16Op {
       (Self::And, U16(x), U16(y)) => Some(U16(x & y)),
       (Self::Or, U16(x), U16(y)) => Some(U16(x | y)),
       (Self::Xor, U16(x), U16(y)) => Some(U16(x ^ y)),
-      (Self::Add, U16(x), U16(y)) => Some(U16(x.wrapping_add(y))),
-      (Self::Sub, U16(x), U16(y)) => Some(U16(x.wrapping_sub(y))),
-      (Self::Mul, U16(x), U16(y)) => Some(U16(x.wrapping_mul(y))),
-      (Self::Div, U16(x), U16(y)) => Some(U16(x.wrapping_div(y))),
-      (Self::Mod, U16(x), U16(y)) => Some(U16(x.wrapping_rem(y))),
-      (Self::Pow, U16(x), U32(y)) => Some(U16(x.wrapping_pow(y))),
-      (Self::Shl, U32(x), U16(y)) => Some(U16(y.wrapping_shl(x))),
-      (Self::Shr, U32(x), U16(y)) => Some(U16(y.wrapping_shr(x))),
-      (Self::Rol, U32(x), U16(y)) => Some(U16(y.rotate_left(x))),
-      (Self::Ror, U32(x), U16(y)) => Some(U16(y.rotate_right(x))),
+      (Self::Add, U16(x), U16(y)) => Some(U16(x.wrapping_add(*y))),
+      (Self::Sub, U16(x), U16(y)) => Some(U16(x.wrapping_sub(*y))),
+      (Self::Mul, U16(x), U16(y)) => Some(U16(x.wrapping_mul(*y))),
+      (Self::Div, U16(x), U16(y)) => Some(U16(x.wrapping_div(*y))),
+      (Self::Mod, U16(x), U16(y)) => Some(U16(x.wrapping_rem(*y))),
+      (Self::Pow, U16(x), U32(y)) => Some(U16(x.wrapping_pow(*y))),
+      (Self::Shl, U32(x), U16(y)) => Some(U16(y.wrapping_shl(*x))),
+      (Self::Shr, U32(x), U16(y)) => Some(U16(y.wrapping_shr(*x))),
+      (Self::Rol, U32(x), U16(y)) => Some(U16(y.rotate_left(*x))),
+      (Self::Ror, U32(x), U16(y)) => Some(U16(y.rotate_right(*x))),
       _ => None,
     }
   }

--- a/yatima_core/src/prim/u32.rs
+++ b/yatima_core/src/prim/u32.rs
@@ -318,32 +318,32 @@ impl U32Op {
     }
   }
 
-  pub fn apply1(self, x: Literal) -> Option<Literal> {
+  pub fn apply1(self, x: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x) {
       (Self::CountZeros, U32(x)) => Some(U32(x.count_zeros())),
       (Self::CountOnes, U32(x)) => Some(U32(x.count_ones())),
-      (Self::ToChar, U32(x)) => char::from_u32(x).map(Char),
-      (Self::ToU8, U32(x)) => u8::try_from(x).ok().map(U8),
-      (Self::ToU16, U32(x)) => u16::try_from(x).ok().map(U16),
-      (Self::ToU64, U32(x)) => Some(U64(x.into())),
-      (Self::ToU128, U32(x)) => Some(U128(x.into())),
-      (Self::ToI8, U32(x)) => i8::try_from(x).ok().map(I8),
-      (Self::ToI16, U32(x)) => i16::try_from(x).ok().map(I16),
-      (Self::ToI32, U32(x)) => i32::try_from(x).ok().map(I32),
-      (Self::ToI64, U32(x)) => Some(I64(x.into())),
-      (Self::ToI128, U32(x)) => Some(I128(x.into())),
+      (Self::ToChar, U32(x)) => char::from_u32(*x).map(Char),
+      (Self::ToU8, U32(x)) => u8::try_from(*x).ok().map(U8),
+      (Self::ToU16, U32(x)) => u16::try_from(*x).ok().map(U16),
+      (Self::ToU64, U32(x)) => Some(U64((*x).into())),
+      (Self::ToU128, U32(x)) => Some(U128((*x).into())),
+      (Self::ToI8, U32(x)) => i8::try_from(*x).ok().map(I8),
+      (Self::ToI16, U32(x)) => i16::try_from(*x).ok().map(I16),
+      (Self::ToI32, U32(x)) => i32::try_from(*x).ok().map(I32),
+      (Self::ToI64, U32(x)) => Some(I64((*x).into())),
+      (Self::ToI128, U32(x)) => Some(I128((*x).into())),
       (Self::Not, U32(x)) => Some(U32(!x)),
-      (Self::ToInt, U32(x)) => Some(Int(x.into())),
+      (Self::ToInt, U32(x)) => Some(Int((*x).into())),
       (Self::ToBytes, U32(x)) => Some(Bytes(x.to_be_bytes().into())),
       (Self::ToBits, U32(x)) => {
-        Some(Bits(bits::bytes_to_bits(32, x.to_be_bytes().into())))
+        Some(Bits(bits::bytes_to_bits(32, &x.to_be_bytes().into())))
       }
       _ => None,
     }
   }
 
-  pub fn apply2(self, x: Literal, y: Literal) -> Option<Literal> {
+  pub fn apply2(self, x: &Literal, y: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x, y) {
       (Self::Eql, U32(x), U32(y)) => Some(Bool(x == y)),
@@ -354,16 +354,16 @@ impl U32Op {
       (Self::And, U32(x), U32(y)) => Some(U32(x & y)),
       (Self::Or, U32(x), U32(y)) => Some(U32(x | y)),
       (Self::Xor, U32(x), U32(y)) => Some(U32(x ^ y)),
-      (Self::Add, U32(x), U32(y)) => Some(U32(x.wrapping_add(y))),
-      (Self::Sub, U32(x), U32(y)) => Some(U32(x.wrapping_sub(y))),
-      (Self::Mul, U32(x), U32(y)) => Some(U32(x.wrapping_mul(y))),
-      (Self::Div, U32(x), U32(y)) => Some(U32(x.wrapping_div(y))),
-      (Self::Mod, U32(x), U32(y)) => Some(U32(x.wrapping_rem(y))),
-      (Self::Pow, U32(x), U32(y)) => Some(U32(x.wrapping_pow(y))),
-      (Self::Shl, U32(x), U32(y)) => Some(U32(y.wrapping_shl(x))),
-      (Self::Shr, U32(x), U32(y)) => Some(U32(y.wrapping_shr(x))),
-      (Self::Rol, U32(x), U32(y)) => Some(U32(y.rotate_left(x))),
-      (Self::Ror, U32(x), U32(y)) => Some(U32(y.rotate_right(x))),
+      (Self::Add, U32(x), U32(y)) => Some(U32(x.wrapping_add(*y))),
+      (Self::Sub, U32(x), U32(y)) => Some(U32(x.wrapping_sub(*y))),
+      (Self::Mul, U32(x), U32(y)) => Some(U32(x.wrapping_mul(*y))),
+      (Self::Div, U32(x), U32(y)) => Some(U32(x.wrapping_div(*y))),
+      (Self::Mod, U32(x), U32(y)) => Some(U32(x.wrapping_rem(*y))),
+      (Self::Pow, U32(x), U32(y)) => Some(U32(x.wrapping_pow(*y))),
+      (Self::Shl, U32(x), U32(y)) => Some(U32(y.wrapping_shl(*x))),
+      (Self::Shr, U32(x), U32(y)) => Some(U32(y.wrapping_shr(*x))),
+      (Self::Rol, U32(x), U32(y)) => Some(U32(y.rotate_left(*x))),
+      (Self::Ror, U32(x), U32(y)) => Some(U32(y.rotate_right(*x))),
       _ => None,
     }
   }

--- a/yatima_core/src/prim/u64.rs
+++ b/yatima_core/src/prim/u64.rs
@@ -311,31 +311,31 @@ impl U64Op {
     }
   }
 
-  pub fn apply1(self, x: Literal) -> Option<Literal> {
+  pub fn apply1(self, x: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x) {
       (Self::CountZeros, U64(x)) => Some(U32(x.count_zeros())),
       (Self::CountOnes, U64(x)) => Some(U32(x.count_ones())),
-      (Self::ToU8, U64(x)) => u8::try_from(x).ok().map(U8),
-      (Self::ToU16, U64(x)) => u16::try_from(x).ok().map(U16),
-      (Self::ToU32, U64(x)) => u32::try_from(x).ok().map(U32),
-      (Self::ToU128, U64(x)) => Some(U128(x.into())),
-      (Self::ToI8, U64(x)) => i8::try_from(x).ok().map(I8),
-      (Self::ToI16, U64(x)) => i16::try_from(x).ok().map(I16),
-      (Self::ToI32, U64(x)) => i32::try_from(x).ok().map(I32),
-      (Self::ToI64, U64(x)) => i64::try_from(x).ok().map(I64),
-      (Self::ToI128, U64(x)) => Some(I128(x.into())),
+      (Self::ToU8, U64(x)) => u8::try_from(*x).ok().map(U8),
+      (Self::ToU16, U64(x)) => u16::try_from(*x).ok().map(U16),
+      (Self::ToU32, U64(x)) => u32::try_from(*x).ok().map(U32),
+      (Self::ToU128, U64(x)) => Some(U128((*x).into())),
+      (Self::ToI8, U64(x)) => i8::try_from(*x).ok().map(I8),
+      (Self::ToI16, U64(x)) => i16::try_from(*x).ok().map(I16),
+      (Self::ToI32, U64(x)) => i32::try_from(*x).ok().map(I32),
+      (Self::ToI64, U64(x)) => i64::try_from(*x).ok().map(I64),
+      (Self::ToI128, U64(x)) => Some(I128((*x).into())),
       (Self::Not, U64(x)) => Some(U64(!x)),
-      (Self::ToInt, U64(x)) => Some(Int(x.into())),
+      (Self::ToInt, U64(x)) => Some(Int((*x).into())),
       (Self::ToBytes, U64(x)) => Some(Bytes(x.to_be_bytes().into())),
       (Self::ToBits, U64(x)) => {
-        Some(Bits(bits::bytes_to_bits(64, x.to_be_bytes().into())))
+        Some(Bits(bits::bytes_to_bits(64, &x.to_be_bytes().into())))
       }
       _ => None,
     }
   }
 
-  pub fn apply2(self, x: Literal, y: Literal) -> Option<Literal> {
+  pub fn apply2(self, x: &Literal, y: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x, y) {
       (Self::Eql, U64(x), U64(y)) => Some(Bool(x == y)),
@@ -346,16 +346,16 @@ impl U64Op {
       (Self::And, U64(x), U64(y)) => Some(U64(x & y)),
       (Self::Or, U64(x), U64(y)) => Some(U64(x | y)),
       (Self::Xor, U64(x), U64(y)) => Some(U64(x ^ y)),
-      (Self::Add, U64(x), U64(y)) => Some(U64(x.wrapping_add(y))),
-      (Self::Sub, U64(x), U64(y)) => Some(U64(x.wrapping_sub(y))),
-      (Self::Mul, U64(x), U64(y)) => Some(U64(x.wrapping_mul(y))),
-      (Self::Div, U64(x), U64(y)) => Some(U64(x.wrapping_div(y))),
-      (Self::Mod, U64(x), U64(y)) => Some(U64(x.wrapping_rem(y))),
-      (Self::Pow, U64(x), U32(y)) => Some(U64(x.wrapping_pow(y))),
-      (Self::Shl, U32(x), U64(y)) => Some(U64(y.wrapping_shl(x))),
-      (Self::Shr, U32(x), U64(y)) => Some(U64(y.wrapping_shr(x))),
-      (Self::Rol, U32(x), U64(y)) => Some(U64(y.rotate_left(x))),
-      (Self::Ror, U32(x), U64(y)) => Some(U64(y.rotate_right(x))),
+      (Self::Add, U64(x), U64(y)) => Some(U64(x.wrapping_add(*y))),
+      (Self::Sub, U64(x), U64(y)) => Some(U64(x.wrapping_sub(*y))),
+      (Self::Mul, U64(x), U64(y)) => Some(U64(x.wrapping_mul(*y))),
+      (Self::Div, U64(x), U64(y)) => Some(U64(x.wrapping_div(*y))),
+      (Self::Mod, U64(x), U64(y)) => Some(U64(x.wrapping_rem(*y))),
+      (Self::Pow, U64(x), U32(y)) => Some(U64(x.wrapping_pow(*y))),
+      (Self::Shl, U32(x), U64(y)) => Some(U64(y.wrapping_shl(*x))),
+      (Self::Shr, U32(x), U64(y)) => Some(U64(y.wrapping_shr(*x))),
+      (Self::Rol, U32(x), U64(y)) => Some(U64(y.rotate_left(*x))),
+      (Self::Ror, U32(x), U64(y)) => Some(U64(y.rotate_right(*x))),
       _ => None,
     }
   }

--- a/yatima_core/src/prim/u8.rs
+++ b/yatima_core/src/prim/u8.rs
@@ -318,32 +318,32 @@ impl U8Op {
     }
   }
 
-  pub fn apply1(self, x: Literal) -> Option<Literal> {
+  pub fn apply1(self, x: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x) {
       (Self::CountZeros, U8(x)) => Some(U32(x.count_zeros())),
       (Self::CountOnes, U8(x)) => Some(U32(x.count_ones())),
-      (Self::ToChar, U8(x)) => Some(Char(x.into())),
-      (Self::ToU16, U8(x)) => Some(U16(x.into())),
-      (Self::ToU32, U8(x)) => Some(U32(x.into())),
-      (Self::ToU64, U8(x)) => Some(U64(x.into())),
-      (Self::ToU128, U8(x)) => Some(U128(x.into())),
-      (Self::ToI8, U8(x)) => i8::try_from(x).ok().map(I8),
-      (Self::ToI16, U8(x)) => Some(I16(x.into())),
-      (Self::ToI32, U8(x)) => Some(I32(x.into())),
-      (Self::ToI64, U8(x)) => Some(I64(x.into())),
-      (Self::ToI128, U8(x)) => Some(I128(x.into())),
+      (Self::ToChar, U8(x)) => Some(Char((*x).into())),
+      (Self::ToU16, U8(x)) => Some(U16((*x).into())),
+      (Self::ToU32, U8(x)) => Some(U32((*x).into())),
+      (Self::ToU64, U8(x)) => Some(U64((*x).into())),
+      (Self::ToU128, U8(x)) => Some(U128((*x).into())),
+      (Self::ToI8, U8(x)) => i8::try_from(*x).ok().map(I8),
+      (Self::ToI16, U8(x)) => Some(I16((*x).into())),
+      (Self::ToI32, U8(x)) => Some(I32((*x).into())),
+      (Self::ToI64, U8(x)) => Some(I64((*x).into())),
+      (Self::ToI128, U8(x)) => Some(I128((*x).into())),
       (Self::Not, U8(x)) => Some(U8(!x)),
-      (Self::ToInt, U8(x)) => Some(Int(x.into())),
+      (Self::ToInt, U8(x)) => Some(Int((*x).into())),
       (Self::ToBytes, U8(x)) => Some(Bytes(x.to_be_bytes().into())),
       (Self::ToBits, U8(x)) => {
-        Some(Bits(bits::bytes_to_bits(8, x.to_be_bytes().into())))
+        Some(Bits(bits::bytes_to_bits(8, &x.to_be_bytes().into())))
       }
       _ => None,
     }
   }
 
-  pub fn apply2(self, x: Literal, y: Literal) -> Option<Literal> {
+  pub fn apply2(self, x: &Literal, y: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x, y) {
       (Self::Eql, U8(x), U8(y)) => Some(Bool(x == y)),
@@ -354,16 +354,16 @@ impl U8Op {
       (Self::And, U8(x), U8(y)) => Some(U8(x & y)),
       (Self::Or, U8(x), U8(y)) => Some(U8(x | y)),
       (Self::Xor, U8(x), U8(y)) => Some(U8(x ^ y)),
-      (Self::Add, U8(x), U8(y)) => Some(U8(x.wrapping_add(y))),
-      (Self::Sub, U8(x), U8(y)) => Some(U8(x.wrapping_sub(y))),
-      (Self::Mul, U8(x), U8(y)) => Some(U8(x.wrapping_mul(y))),
-      (Self::Div, U8(x), U8(y)) => Some(U8(x.wrapping_div(y))),
-      (Self::Mod, U8(x), U8(y)) => Some(U8(x.wrapping_rem(y))),
-      (Self::Pow, U8(x), U32(y)) => Some(U8(x.wrapping_pow(y))),
-      (Self::Shl, U32(x), U8(y)) => Some(U8(y.wrapping_shl(x))),
-      (Self::Shr, U32(x), U8(y)) => Some(U8(y.wrapping_shr(x))),
-      (Self::Rol, U32(x), U8(y)) => Some(U8(y.rotate_left(x))),
-      (Self::Ror, U32(x), U8(y)) => Some(U8(y.rotate_right(x))),
+      (Self::Add, U8(x), U8(y)) => Some(U8(x.wrapping_add(*y))),
+      (Self::Sub, U8(x), U8(y)) => Some(U8(x.wrapping_sub(*y))),
+      (Self::Mul, U8(x), U8(y)) => Some(U8(x.wrapping_mul(*y))),
+      (Self::Div, U8(x), U8(y)) => Some(U8(x.wrapping_div(*y))),
+      (Self::Mod, U8(x), U8(y)) => Some(U8(x.wrapping_rem(*y))),
+      (Self::Pow, U8(x), U32(y)) => Some(U8(x.wrapping_pow(*y))),
+      (Self::Shl, U32(x), U8(y)) => Some(U8(y.wrapping_shl(*x))),
+      (Self::Shr, U32(x), U8(y)) => Some(U8(y.wrapping_shr(*x))),
+      (Self::Rol, U32(x), U8(y)) => Some(U8(y.rotate_left(*x))),
+      (Self::Ror, U32(x), U8(y)) => Some(U8(y.rotate_right(*x))),
       _ => None,
     }
   }


### PR DESCRIPTION
Instead of needlessly cloning, primitive operations now borrow the arguments, only cloning when necessary. Note: there are a bunch of clones `text.rs`, but only because cloning is `O(1)` in Ropey