### PR TITLE
Add prim op tests

### DIFF
--- a/core/src/prim.rs
+++ b/core/src/prim.rs
@@ -274,7 +274,7 @@ pub mod tests {
   impl Arbitrary for Op {
     fn arbitrary(g: &mut Gen) -> Self {
       let mut rng = rand::thread_rng();
-      let gen: u32 = rng.gen_range(0..11);
+      let gen: u32 = rng.gen_range(0..=13);
       match gen {
         0 => Self::Nat(NatOp::arbitrary(g)),
         1 => Self::Int(IntOp::arbitrary(g)),
@@ -286,11 +286,11 @@ pub mod tests {
         7 => Self::U16(U16Op::arbitrary(g)),
         8 => Self::U32(U32Op::arbitrary(g)),
         9 => Self::U64(U64Op::arbitrary(g)),
-        // 10 => Self::U128(U128Op::arbitrary(g)),
-        11 => Self::I8(I8Op::arbitrary(g)),
-        12 => Self::I16(I16Op::arbitrary(g)),
-        13 => Self::I32(I32Op::arbitrary(g)),
+        10 => Self::I8(I8Op::arbitrary(g)),
+        11 => Self::I16(I16Op::arbitrary(g)),
+        12 => Self::I32(I32Op::arbitrary(g)),
         _ => Self::I64(I64Op::arbitrary(g)),
+        // 10 => Self::U128(U128Op::arbitrary(g)),
         // _ => Self::I128(I128Op::arbitrary(g)),
       }
     }
@@ -301,6 +301,25 @@ pub mod tests {
     match Op::from_ipld(&x.to_ipld()) {
       Ok(y) => x == y,
       _ => false,
+    }
+  }
+
+  #[derive(Clone, Debug)]
+  pub enum TestArg3 {
+    A,
+    B,
+    C
+  }
+
+  impl Arbitrary for TestArg3 {
+    fn arbitrary(_g: &mut Gen) -> Self {
+      let mut rng = rand::thread_rng();
+      let gen: u32 = rng.gen_range(0..=2);
+      match gen {
+        0 => Self::A,
+        1 => Self::B,
+        _ => Self::C
+      }
     }
   }
 }

--- a/core/src/prim/bits.rs
+++ b/core/src/prim/bits.rs
@@ -132,11 +132,14 @@ impl BitsOp {
       (Self::Head, Bits(xs)) => {
         let x = xs.last();
         x.map(|x| Bool(*x))
-      }
-      (Self::Tail, Bits(xs)) => {
-        let xs = xs[0..xs.len() - 1].to_vec();
-        Some(Bits(xs))
-      }
+      },
+      (Self::Tail, Bits(xs)) => Some(Bits(
+        if xs.is_empty() {
+          vec![]
+        } else {
+          xs[0..xs.len() - 1].to_vec()
+        }
+      )),
       (Self::ToBytes, Bits(xs)) => Some(Literal::Bytes(bits_to_bytes(xs).1)),
       _ => None,
     }
@@ -287,12 +290,25 @@ pub mod tests {
   use quickcheck::{
     Arbitrary,
     Gen,
+    TestResult
   };
   use rand::Rng;
+  use Literal::{
+    Nat,
+    Bool,
+  };
+  use crate::prim::{
+    BytesOp,
+    tests::TestArg3
+  };
+  use std::{
+    convert::TryInto,
+    mem
+  };
   impl Arbitrary for BitsOp {
     fn arbitrary(_g: &mut Gen) -> Self {
       let mut rng = rand::thread_rng();
-      let gen: u32 = rng.gen_range(0..9);
+      let gen: u32 = rng.gen_range(0..=10);
       match gen {
         0 => Self::Cons,
         1 => Self::Len,
@@ -303,7 +319,8 @@ pub mod tests {
         6 => Self::Append,
         7 => Self::Insert,
         8 => Self::Remove,
-        _ => Self::Index,
+        9 => Self::Index,
+        _ => Self::ToBytes,
       }
     }
   }
@@ -347,5 +364,311 @@ pub mod tests {
   fn test_bytes_to_bits(x: Vec<u8>) -> bool {
     let len = x.len() * 8;
     bits_to_bytes(&bytes_to_bits(len, &x)) == (len, x)
+  }
+
+  #[quickcheck]
+  fn test_apply(
+    op: BitsOp,
+    a: Vec<bool>,
+    b: bool,
+    c: u64,
+    d: Vec<bool>
+  ) -> TestResult {
+    let big = BigUint::from;
+    let apply1_bits = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        BitsOp::apply1(
+          op,
+          &Literal::Bits(a.clone())
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_bool_bits = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        BitsOp::apply2(
+          op,
+          &Bool(b),
+          &Literal::Bits(a.clone())
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_nat_bits = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        BitsOp::apply2(
+          op,
+          &Nat(big(c)),
+          &Literal::Bits(a.clone())
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_bits_bits = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        BitsOp::apply2(
+          op,
+          &Literal::Bits(a.clone()),
+          &Literal::Bits(d.clone())
+        ) ==
+        expected
+      )
+    };
+
+    let apply3_nat_bool_bits = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        BitsOp::apply3(
+          op,
+          &Nat(big(c)),
+          &Bool(b),
+          &Literal::Bits(a.clone())
+        ) ==
+        expected
+      )
+    };
+
+    let from_bool = TestResult::from_bool;
+
+    match op {
+      BitsOp::Cons => {
+        let mut a = a.clone();
+        a.push(b);
+        apply2_bool_bits(Some(Literal::Bits(a)))
+      },
+      BitsOp::Len => apply1_bits(Some(Nat(a.len().into()))),
+      BitsOp::Head => apply1_bits(a.last().map(|z| Bool(*z))),
+      BitsOp::Tail => apply1_bits(Some(Literal::Bits(
+        if a.is_empty() {
+          vec![]
+        } else {
+          a[0..a.len() - 1].to_vec()
+        }
+      ))),
+      BitsOp::Take => apply2_nat_bits(Some(Literal::Bits(safe_split(&big(c), &a).0))),
+      BitsOp::Drop => apply2_nat_bits(Some(Literal::Bits(safe_split(&big(c), &a).1))),
+      BitsOp::Append => {
+        let mut a = a.clone();
+        a.extend_from_slice(&d);
+        apply2_bits_bits(Some(Literal::Bits(a)))
+      },
+      BitsOp::Insert => {
+        let idx = usize::try_from(c);
+        match idx {
+          Ok(idx) if idx < a.len() => {
+            let mut a = a.clone();
+            a.insert(idx, b);
+            apply3_nat_bool_bits(Some(Literal::Bits(a)))
+          }
+          _ => apply3_nat_bool_bits(Some(Literal::Bits(a.clone()))),
+        }
+      },
+      BitsOp::Remove => {
+        let idx = usize::try_from(c);
+        match idx {
+          Ok(idx) if idx < a.len() => {
+            let mut a = a.clone();
+            a.remove(idx);
+            apply2_nat_bits(Some(Literal::Bits(a)))
+          }
+          _ => apply2_nat_bits(Some(Literal::Bits(a.clone()))),
+        }
+      },
+      BitsOp::Index => {
+        let idx = usize::try_from(c);
+        match idx {
+          Ok(idx) if idx < a.len() => apply2_nat_bits(Some(Bool(a[idx]))),
+          _ => apply2_nat_bits(None),
+        }
+      },
+      BitsOp::ToBytes => {
+        let bytes = BitsOp::apply1(op, &Literal::Bits(a.clone()));
+        match bytes {
+          None => apply1_bits(None),
+          Some(bytes_) => match bytes_.clone() {
+            Literal::Bytes(_) => {
+              let bits = BytesOp::apply2(
+                BytesOp::ToBits,
+                &Literal::Nat(big(a.len().try_into().unwrap())),
+                &bytes_
+              );
+              match bits {
+                None => apply1_bits(None),
+                Some(bits_) => from_bool(
+                  bits_ == Literal::Bits(a.clone())
+                )
+              }
+            },
+            _ => apply1_bits(None),
+          }
+        }
+      }
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply_none_on_invalid(
+    op: BitsOp,
+    a: Literal,
+    b: Vec<bool>,
+    c: bool,
+    d: u64,
+    test_arg_2: bool,
+    test_arg_3: TestArg3,
+  ) -> TestResult {
+    let big = BigUint::from;
+    let test_apply1_none_on_invalid = |
+      valid_arg: Literal
+    | -> TestResult {
+      if mem::discriminant(&valid_arg) == mem::discriminant(&a) {
+        TestResult::discard()
+      } else {
+        TestResult::from_bool(
+          BitsOp::apply1(
+            op,
+            &a
+          ) ==
+          None
+        )
+      }
+    };
+
+    let test_apply2_none_on_invalid = |
+      valid_arg: Literal,
+      a_: Literal,
+      b_: Literal
+    | -> TestResult {
+      let go = || TestResult::from_bool(
+        BitsOp::apply2(
+          op,
+          &a_,
+          &b_
+        ) ==
+        None
+      );
+      if test_arg_2 {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&a_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      } else {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&b_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      }
+    };
+
+    let test_apply3_none_on_invalid = |
+      valid_arg: Literal,
+      a_: Literal,
+      b_: Literal,
+      c_: Literal
+    | -> TestResult {
+      let go = || TestResult::from_bool(
+        BitsOp::apply3(
+          op,
+          &a_,
+          &b_,
+          &c_
+        ) ==
+        None
+      );
+      match test_arg_3 {
+        TestArg3::A => if mem::discriminant(&valid_arg) == mem::discriminant(&a_) {
+          TestResult::discard()
+        } else {
+          go()
+        },
+        TestArg3::B => if mem::discriminant(&valid_arg) == mem::discriminant(&b_) {
+          TestResult::discard()
+        } else {
+          go()
+        },
+        TestArg3::C => if mem::discriminant(&valid_arg) == mem::discriminant(&c_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      }
+    };
+
+    match op {
+      // Arity 1, valid is Bits.
+      BitsOp::Len |
+      BitsOp::Head |
+      BitsOp::Tail |
+      BitsOp::ToBytes => test_apply1_none_on_invalid(Literal::Bits(b)),
+      // Arity 2, valid are Bool on a and Bits on b.
+      BitsOp::Cons => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          Bool(c),
+          a,
+          Literal::Bits(b)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          Literal::Bits(b),
+          Bool(c),
+          a
+        )
+      },
+      // Arity 2, valid are Nat on a and Bits on b.
+      BitsOp::Take |
+      BitsOp::Drop |
+      BitsOp::Remove |
+      BitsOp::Index => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          Nat(big(d)),
+          a,
+          Literal::Bits(b)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          Literal::Bits(b),
+          Nat(big(d)),
+          a
+        )
+      },
+      // Arity 2, valid are Bits on a and b.
+      BitsOp::Append => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          Literal::Bits(b.clone()),
+          a,
+          Literal::Bits(b)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          Literal::Bits(b.clone()),
+          Literal::Bits(b),
+          a
+        )
+      },
+      // Arity 3, valid are Nat on a, Bool on b and Bits on c.
+      BitsOp::Insert => match test_arg_3 {
+        TestArg3::A => test_apply3_none_on_invalid(
+          Nat(big(d)),
+          a,
+          Bool(c),
+          Literal::Bits(b)
+        ),
+        TestArg3::B => test_apply3_none_on_invalid(
+          Bool(c),
+          Nat(big(d)),
+          a,
+          Literal::Bits(b)
+        ),
+        TestArg3::C => test_apply3_none_on_invalid(
+          Literal::Bits(b),
+          Nat(big(d)),
+          Bool(c),
+          a
+        ),
+      }
+    }
   }
 }

--- a/core/src/prim/bool.rs
+++ b/core/src/prim/bool.rs
@@ -121,8 +121,9 @@ impl BoolOp {
     use Literal::*;
     match (self, x, y) {
       (Self::Eql, Bool(x), Bool(y)) => Some(Bool(x == y)),
-      (Self::Lth, Bool(x), Bool(y)) => Some(Bool(x < y)),
       (Self::Lte, Bool(x), Bool(y)) => Some(Bool(x <= y)),
+      (Self::Lth, Bool(x), Bool(y)) => Some(Bool(x < y)),
+      (Self::Gte, Bool(x), Bool(y)) => Some(Bool(x >= y)),
       (Self::Gth, Bool(x), Bool(y)) => Some(Bool(x > y)),
       (Self::And, Bool(x), Bool(y)) => Some(Bool(x & y)),
       (Self::Or, Bool(x), Bool(y)) => Some(Bool(x | y)),
@@ -144,12 +145,15 @@ pub mod tests {
   use quickcheck::{
     Arbitrary,
     Gen,
+    TestResult
   };
   use rand::Rng;
+  use Literal::Bool;
+  use std::mem;
   impl Arbitrary for BoolOp {
     fn arbitrary(_g: &mut Gen) -> Self {
       let mut rng = rand::thread_rng();
-      let gen: u32 = rng.gen_range(0..8);
+      let gen: u32 = rng.gen_range(0..=8);
       match gen {
         0 => Self::Eql,
         1 => Self::Lte,
@@ -170,6 +174,350 @@ pub mod tests {
       Ok(y) => x == y,
       _ => false,
     }
+  }
+
+  #[quickcheck]
+  fn test_apply(
+    op: BoolOp,
+    a: bool,
+    b: bool
+  ) -> TestResult {
+    let apply1_bool = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        BoolOp::apply1(
+          op,
+          &Bool(a)
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_bool_bool = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        BoolOp::apply2(
+          op,
+          &Bool(a),
+          &Bool(b)
+        ) ==
+        expected
+      )
+    };
+
+    match op {
+      BoolOp::Eql => apply2_bool_bool(Some(Bool(a == b))),
+      BoolOp::Lte => apply2_bool_bool(Some(Bool(a <= b))),
+      BoolOp::Lth => apply2_bool_bool(Some(Bool(a < b))),
+      BoolOp::Gte => apply2_bool_bool(Some(Bool(a >= b))),
+      BoolOp::Gth => apply2_bool_bool(Some(Bool(a > b))),
+      BoolOp::And => apply2_bool_bool(Some(Bool(a && b))),
+      BoolOp::Or => apply2_bool_bool(Some(Bool(a || b))),
+      BoolOp::Xor => apply2_bool_bool(Some(Bool(a ^ b))),
+      BoolOp::Not => apply1_bool(Some(Bool(!a))),
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply_none_on_invalid(
+    op: BoolOp,
+    a: Literal,
+    b: bool,
+    test_arg_2: bool,
+  ) -> TestResult {
+    let test_apply1_none_on_invalid = |
+      valid_arg: Literal
+    | -> TestResult {
+      if mem::discriminant(&valid_arg) == mem::discriminant(&a) {
+        TestResult::discard()
+      } else {
+        TestResult::from_bool(
+          BoolOp::apply1(
+            op,
+            &a
+          ) ==
+          None
+        )
+      }
+    };
+
+    let test_apply2_none_on_invalid = |
+      valid_arg: Literal,
+      a_: Literal,
+      b_: Literal
+    | -> TestResult {
+      let go = || TestResult::from_bool(
+        BoolOp::apply2(
+          op,
+          &a_,
+          &b_
+        ) ==
+        None
+      );
+      if test_arg_2 {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&a_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      } else {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&b_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      }
+    };
+
+    match op {
+      // Arity 1, valid is Bool.
+      BoolOp::Not => test_apply1_none_on_invalid(Bool(b)),
+      // Arity 2, valid are Bool on a and b.
+      BoolOp::Eql |
+      BoolOp::Lte |
+      BoolOp::Lth |
+      BoolOp::Gte |
+      BoolOp::Gth |
+      BoolOp::And |
+      BoolOp::Or |
+      BoolOp::Xor => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          Bool(b),
+          a,
+          Bool(b)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          Bool(b),
+          Bool(b),
+          a
+        )
+      }
+    }
+  }
+
+  #[quickcheck]
+  fn test_associativity(
+    op: BoolOp,
+    a: bool,
+    b: bool,
+    c: bool
+  ) -> TestResult {
+    match op {
+      BoolOp::Or |
+      BoolOp::And => TestResult::from_bool(
+        BoolOp::apply2(
+          op,
+          &Bool(a),
+          &BoolOp::apply2(op, &Bool(b), &Bool(c)).unwrap()
+        ) ==
+        BoolOp::apply2(
+          op,
+          &BoolOp::apply2(op, &Bool(a), &Bool(b)).unwrap(),
+          &Bool(c)
+        )
+      ),
+      _ => TestResult::discard()
+    }
+  }
+
+  #[quickcheck]
+  fn test_commutativity(
+    op: BoolOp,
+    left: bool,
+    right: bool
+  ) -> TestResult {
+    match op {
+      BoolOp::Or |
+      BoolOp::And => TestResult::from_bool(
+        BoolOp::apply2(
+          op,
+          &Bool(left),
+          &Bool(right)
+        ) ==
+        BoolOp::apply2(
+          op,
+          &Bool(left),
+          &Bool(right)
+        )
+      ),
+      _ => TestResult::discard()
+    }
+  }
+
+  #[quickcheck]
+  fn test_distributivity_of_and_over_or(
+    a: bool,
+    b: bool,
+    c: bool
+  ) -> bool {
+    BoolOp::apply2(
+      BoolOp::And,
+      &Bool(a),
+      &BoolOp::apply2(
+        BoolOp::Or,
+        &Bool(b),
+        &Bool(c)
+      ).unwrap()
+    ) ==
+    BoolOp::apply2(
+      BoolOp::Or,
+      &BoolOp::apply2(
+        BoolOp::And,
+        &Bool(a),
+        &Bool(b)
+      ).unwrap(),
+      &BoolOp::apply2(
+        BoolOp::And,
+        &Bool(a),
+        &Bool(c)
+      ).unwrap()
+    )
+  }
+
+  #[quickcheck]
+  fn test_idempotence(
+    op: BoolOp,
+    input: bool
+  ) -> TestResult {
+    match op {
+      BoolOp::Or |
+      BoolOp::And => TestResult::from_bool(
+        BoolOp::apply2(
+          op,
+          &Bool(input),
+          &Bool(input)
+        ) ==
+        Some(Bool(input))
+      ),
+      _ => TestResult::discard()
+    }
+  }
+
+  #[quickcheck]
+  fn test_absorption_1(
+    a: bool,
+    b: bool
+  ) -> bool {
+    BoolOp::apply2(
+      BoolOp::And,
+      &Bool(a),
+      &BoolOp::apply2(
+        BoolOp::Or,
+        &Bool(a),
+        &Bool(b)
+      ).unwrap()
+    ) ==
+    Some(Bool(a))
+  }
+
+  #[quickcheck]
+  fn test_absorption_2(
+    a: bool,
+    b: bool
+  ) -> bool {
+    BoolOp::apply2(
+      BoolOp::Or,
+      &Bool(a),
+      &BoolOp::apply2(
+        BoolOp::And,
+        &Bool(a),
+        &Bool(b)
+      ).unwrap()
+    ) ==
+    Some(Bool(a))
+  }
+
+  #[quickcheck]
+  fn test_distributivity_of_or_over_and(
+    a: bool,
+    b: bool,
+    c: bool
+  ) -> bool {
+    BoolOp::apply2(
+      BoolOp::Or,
+      &Bool(a),
+      &BoolOp::apply2(
+        BoolOp::And,
+        &Bool(b),
+        &Bool(c)
+      ).unwrap()
+    ) ==
+    BoolOp::apply2(
+      BoolOp::And,
+      &BoolOp::apply2(
+        BoolOp::Or,
+        &Bool(a),
+        &Bool(b)
+      ).unwrap(),
+      &BoolOp::apply2(
+        BoolOp::Or,
+        &Bool(a),
+        &Bool(c)
+      ).unwrap()
+    )
+  }
+
+  #[quickcheck]
+  fn test_double_negation(input: bool) -> bool {
+    BoolOp::apply1(
+      BoolOp::Not,
+      &BoolOp::apply1(
+        BoolOp::Not,
+        &Bool(input)
+      ).unwrap()
+    ) ==
+    Some(Bool(input))
+  }
+
+  #[quickcheck]
+  fn test_de_morgan_1(
+    a: bool,
+    b: bool
+  ) -> bool {
+    BoolOp::apply2(
+      BoolOp::And,
+      &BoolOp::apply1(
+        BoolOp::Not,
+        &Bool(a)
+      ).unwrap(),
+      &BoolOp::apply1(
+        BoolOp::Not,
+        &Bool(b)
+      ).unwrap()
+    ) ==
+    BoolOp::apply1(
+      BoolOp::Not,
+      &BoolOp::apply2(
+        BoolOp::Or,
+        &Bool(a),
+        &Bool(b)
+      ).unwrap()
+    )
+  }
+
+  #[quickcheck]
+  fn test_de_morgan_2(
+    a: bool,
+    b: bool
+  ) -> bool {
+    BoolOp::apply2(
+      BoolOp::Or,
+      &BoolOp::apply1(
+        BoolOp::Not,
+        &Bool(a)
+      ).unwrap(),
+      &BoolOp::apply1(
+        BoolOp::Not,
+        &Bool(b)
+      ).unwrap()
+    ) ==
+    BoolOp::apply1(
+      BoolOp::Not,
+      &BoolOp::apply2(
+        BoolOp::And,
+        &Bool(a),
+        &Bool(b)
+      ).unwrap()
+    )
   }
 
   //#[test]

--- a/core/src/prim/bytes.rs
+++ b/core/src/prim/bytes.rs
@@ -134,10 +134,13 @@ impl BytesOp {
         let x = xs.last();
         x.map(|x| U8(*x))
       }
-      (Self::Tail, Bytes(xs)) => {
-        let xs = xs[0..xs.len() - 1].to_vec();
-        Some(Bytes(xs))
-      }
+      (Self::Tail, Bytes(xs)) => Some(Bytes(
+        if xs.is_empty() {
+          vec![]
+        } else {
+          xs[0..xs.len() - 1].to_vec()
+        }
+      )),
       _ => None,
     }
   }
@@ -240,12 +243,28 @@ pub mod tests {
   use quickcheck::{
     Arbitrary,
     Gen,
+    TestResult
   };
   use rand::Rng;
+  use Literal::{
+    Nat,
+    U8,
+    Bytes,
+    Bits
+  };
+  use crate::prim::{
+    BytesOp,
+    BitsOp,
+    tests::TestArg3
+  };
+  use std::{
+    convert::TryInto,
+    mem
+  };
   impl Arbitrary for BytesOp {
     fn arbitrary(_g: &mut Gen) -> Self {
       let mut rng = rand::thread_rng();
-      let gen: u32 = rng.gen_range(0..9);
+      let gen: u32 = rng.gen_range(0..=10);
       match gen {
         0 => Self::Cons,
         1 => Self::Len,
@@ -256,7 +275,8 @@ pub mod tests {
         6 => Self::Append,
         7 => Self::Insert,
         8 => Self::Remove,
-        _ => Self::Index,
+        9 => Self::Index,
+        _ => Self::ToBits,
       }
     }
   }
@@ -266,6 +286,312 @@ pub mod tests {
     match BytesOp::from_ipld(&x.to_ipld()) {
       Ok(y) => x == y,
       _ => false,
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply(
+    op: BytesOp,
+    a: Vec<u8>,
+    b: u8,
+    c: u64,
+    d: Vec<u8>
+  ) -> TestResult {
+    let big = BigUint::from;
+    let apply1_bytes = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        BytesOp::apply1(
+          op,
+          &Bytes(a.clone())
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_u8_bytes = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        BytesOp::apply2(
+          op,
+          &U8(b),
+          &Bytes(a.clone())
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_nat_bytes = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        BytesOp::apply2(
+          op,
+          &Nat(big(c)),
+          &Bytes(a.clone())
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_bytes_bytes = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        BytesOp::apply2(
+          op,
+          &Bytes(a.clone()),
+          &Bytes(d.clone())
+        ) ==
+        expected
+      )
+    };
+
+    let apply3_nat_u8_bytes = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        BytesOp::apply3(
+          op,
+          &Nat(big(c)),
+          &U8(b),
+          &Bytes(a.clone())
+        ) ==
+        expected
+      )
+    };
+
+    let from_bool = TestResult::from_bool;
+
+    match op {
+      BytesOp::Cons => {
+        let mut a = a.clone();
+        a.push(b);
+        apply2_u8_bytes(Some(Bytes(a)))
+      },
+      BytesOp::Len => apply1_bytes(Some(Nat(a.len().into()))),
+      BytesOp::Head => apply1_bytes(a.last().map(|z| U8(*z))),
+      BytesOp::Tail => apply1_bytes(Some(Bytes(
+        if a.is_empty() {
+          vec![]
+        } else {
+          a[0..a.len() - 1].to_vec()
+        }
+      ))),
+      BytesOp::Take => apply2_nat_bytes(Some(Bytes(safe_split(&big(c), &a).0))),
+      BytesOp::Drop => apply2_nat_bytes(Some(Bytes(safe_split(&big(c), &a).1))),
+      BytesOp::Append => {
+        let mut a = a.clone();
+        a.extend_from_slice(&d);
+        apply2_bytes_bytes(Some(Bytes(a)))
+      },
+      BytesOp::Insert => {
+        let idx = usize::try_from(c);
+        match idx {
+          Ok(idx) if idx < a.len() => {
+            let mut a = a.clone();
+            a.insert(idx, b);
+            apply3_nat_u8_bytes(Some(Bytes(a)))
+          }
+          _ => apply3_nat_u8_bytes(Some(Bytes(a.clone()))),
+        }
+      },
+      BytesOp::Remove => {
+        let idx = usize::try_from(c);
+        match idx {
+          Ok(idx) if idx < a.len() => {
+            let mut a = a.clone();
+            a.remove(idx);
+            apply2_nat_bytes(Some(Bytes(a)))
+          }
+          _ => apply2_nat_bytes(Some(Bytes(a.clone()))),
+        }
+      },
+      BytesOp::Index => {
+        let idx = usize::try_from(c);
+        match idx {
+          Ok(idx) if idx < a.len() => apply2_nat_bytes(Some(U8(a[idx]))),
+          _ => apply2_nat_bytes(None),
+        }
+      },
+      BytesOp::ToBits => {
+        let bits = BytesOp::apply1(op, &Bytes(a.clone()));
+        match bits {
+          None => apply1_bytes(None),
+          Some(bits_) => match bits_.clone() {
+            Bits(_) => {
+              let bytes = BitsOp::apply2(
+                BitsOp::ToBytes,
+                &Nat(big(a.len().try_into().unwrap())),
+                &bits_
+              );
+              match bytes {
+                None => apply1_bytes(None),
+                Some(bytes_) => from_bool(
+                  bytes_ == Bytes(a.clone())
+                )
+              }
+            },
+            _ => apply1_bytes(None),
+          }
+        }
+      }
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply_none_on_invalid(
+    op: BytesOp,
+    a: Literal,
+    b: Vec<u8>,
+    c: u8,
+    d: u64,
+    test_arg_2: bool,
+    test_arg_3: TestArg3,
+  ) -> TestResult {
+    let big = BigUint::from;
+    let test_apply1_none_on_invalid = |
+      valid_arg: Literal
+    | -> TestResult {
+      if mem::discriminant(&valid_arg) == mem::discriminant(&a) {
+        TestResult::discard()
+      } else {
+        TestResult::from_bool(
+          BytesOp::apply1(
+            op,
+            &a
+          ) ==
+          None
+        )
+      }
+    };
+
+    let test_apply2_none_on_invalid = |
+      valid_arg: Literal,
+      a_: Literal,
+      b_: Literal
+    | -> TestResult {
+      let go = || TestResult::from_bool(
+        BytesOp::apply2(
+          op,
+          &a_,
+          &b_
+        ) ==
+        None
+      );
+      if test_arg_2 {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&a_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      } else {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&b_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      }
+    };
+
+    let test_apply3_none_on_invalid = |
+      valid_arg: Literal,
+      a_: Literal,
+      b_: Literal,
+      c_: Literal
+    | -> TestResult {
+      let go = || TestResult::from_bool(
+        BytesOp::apply3(
+          op,
+          &a_,
+          &b_,
+          &c_
+        ) ==
+        None
+      );
+      match test_arg_3 {
+        TestArg3::A => if mem::discriminant(&valid_arg) == mem::discriminant(&a_) {
+          TestResult::discard()
+        } else {
+          go()
+        },
+        TestArg3::B => if mem::discriminant(&valid_arg) == mem::discriminant(&b_) {
+          TestResult::discard()
+        } else {
+          go()
+        },
+        TestArg3::C => if mem::discriminant(&valid_arg) == mem::discriminant(&c_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      }
+    };
+
+    match op {
+      // Arity 1, valid is Bytes.
+      BytesOp::Len |
+      BytesOp::Head |
+      BytesOp::Tail => test_apply1_none_on_invalid(Bytes(b)),
+      // Arity 2, valid are U8 on a and Bytes on b.
+      BytesOp::Cons => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          U8(c),
+          a,
+          Bytes(b)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          Bytes(b),
+          U8(c),
+          a
+        )
+      },
+      // Arity 2, valid are Nat on a and Bytes on b.
+      BytesOp::Take |
+      BytesOp::Drop |
+      BytesOp::Remove |
+      BytesOp::Index |
+      BytesOp::ToBits => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          Nat(big(d)),
+          a,
+          Bytes(b)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          Bytes(b),
+          Nat(big(d)),
+          a
+        )
+      },
+      // Arity 2, valid are Bytes on a and b.
+      BytesOp::Append => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          Bytes(b.clone()),
+          a,
+          Bytes(b)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          Bytes(b.clone()),
+          Bytes(b),
+          a
+        )
+      },
+      // Arity 3, valid are Nat on a, U8 on b and Bytes on c.
+      BytesOp::Insert => match test_arg_3 {
+        TestArg3::A => test_apply3_none_on_invalid(
+          Nat(big(d)),
+          a,
+          U8(c),
+          Bytes(b)
+        ),
+        TestArg3::B => test_apply3_none_on_invalid(
+          U8(c),
+          Nat(big(d)),
+          a,
+          Bytes(b)
+        ),
+        TestArg3::C => test_apply3_none_on_invalid(
+          Bytes(b),
+          Nat(big(d)),
+          U8(c),
+          a
+        ),
+      }
     }
   }
 }

--- a/core/src/prim/char.rs
+++ b/core/src/prim/char.rs
@@ -197,8 +197,8 @@ impl CharOp {
       Ipld::Integer(22) => Ok(Self::LenUTF16),
       Ipld::Integer(23) => Ok(Self::ToAsciiLowercase),
       Ipld::Integer(24) => Ok(Self::ToAsciiUppercase),
-      Ipld::Integer(25) => Ok(Self::ToAsciiLowercase),
-      Ipld::Integer(26) => Ok(Self::ToAsciiUppercase),
+      Ipld::Integer(25) => Ok(Self::ToLowercase),
+      Ipld::Integer(26) => Ok(Self::ToUppercase),
       xs => Err(IpldError::CharOp(xs.to_owned())),
     }
   }
@@ -244,17 +244,13 @@ impl CharOp {
       (Self::IsAlphanumeric, Char(x)) => Some(Bool(x.is_alphanumeric())),
       (Self::IsAscii, Char(x)) => Some(Bool(x.is_ascii())),
       (Self::IsAsciiAlphabetic, Char(x)) => Some(Bool(x.is_ascii_alphabetic())),
-      (Self::IsAsciiAlphanumeric, Char(x)) => {
-        Some(Bool(x.is_ascii_alphanumeric()))
-      }
+      (Self::IsAsciiAlphanumeric, Char(x)) => Some(Bool(x.is_ascii_alphanumeric())),
       (Self::IsAsciiControl, Char(x)) => Some(Bool(x.is_ascii_control())),
       (Self::IsAsciiDigit, Char(x)) => Some(Bool(x.is_ascii_digit())),
       (Self::IsAsciiGraphic, Char(x)) => Some(Bool(x.is_ascii_graphic())),
       (Self::IsAsciiHexDigit, Char(x)) => Some(Bool(x.is_ascii_hexdigit())),
       (Self::IsAsciiLowerCase, Char(x)) => Some(Bool(x.is_ascii_lowercase())),
-      (Self::IsAsciiPunctuation, Char(x)) => {
-        Some(Bool(x.is_ascii_punctuation()))
-      }
+      (Self::IsAsciiPunctuation, Char(x)) => Some(Bool(x.is_ascii_punctuation())),
       (Self::IsAsciiUpperCase, Char(x)) => Some(Bool(x.is_ascii_uppercase())),
       (Self::IsAsciiWhitespace, Char(x)) => Some(Bool(x.is_ascii_whitespace())),
       (Self::IsControl, Char(x)) => Some(Bool(x.is_control())),
@@ -266,12 +262,8 @@ impl CharOp {
       (Self::LenUTF16, Char(x)) => Some(Nat(x.len_utf16().into())),
       (Self::ToAsciiLowercase, Char(x)) => Some(Char(x.to_ascii_lowercase())),
       (Self::ToAsciiUppercase, Char(x)) => Some(Char(x.to_ascii_uppercase())),
-      (Self::ToLowercase, Char(x)) => {
-        Some(Text(x.to_lowercase().to_string().into()))
-      }
-      (Self::ToUppercase, Char(x)) => {
-        Some(Text(x.to_uppercase().to_string().into()))
-      }
+      (Self::ToLowercase, Char(x)) => Some(Text(x.to_lowercase().to_string().into())),
+      (Self::ToUppercase, Char(x)) => Some(Text(x.to_uppercase().to_string().into())),
       _ => None,
     }
   }
@@ -279,7 +271,12 @@ impl CharOp {
   pub fn apply2(self, x: &Literal, y: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x, y) {
-      (Self::IsDigit, Char(x), U32(y)) => Some(Bool(x.is_digit(*y))),
+      // TODO: Hardcoding the maximum radix here is probably bad, not sure how to do it differently though.
+      (Self::IsDigit, Char(x), U32(y)) => if *y > 36 {
+        None
+      } else {
+        Some(Bool(x.is_digit(*y)))
+      },
       _ => None,
     }
   }
@@ -297,12 +294,21 @@ pub mod tests {
   use quickcheck::{
     Arbitrary,
     Gen,
+    TestResult
   };
   use rand::Rng;
+  use Literal::{
+    U32,
+    Char,
+    Bool,
+    Nat,
+    Text
+  };
+  use std::mem;
   impl Arbitrary for CharOp {
     fn arbitrary(_g: &mut Gen) -> Self {
       let mut rng = rand::thread_rng();
-      let gen: u32 = rng.gen_range(0..11);
+      let gen: u32 = rng.gen_range(0..=26);
       match gen {
         0 => Self::FromU32,
         1 => Self::ToU32,
@@ -340,6 +346,179 @@ pub mod tests {
     match CharOp::from_ipld(&x.to_ipld()) {
       Ok(y) => x == y,
       _ => false,
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply(
+    op: CharOp,
+    a: u32,
+    b: char
+  ) -> TestResult {
+    let apply1_u32 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        CharOp::apply1(
+          op,
+          &U32(a)
+        ) ==
+        expected
+      )
+    };
+
+    let apply1_char = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        CharOp::apply1(
+          op,
+          &Char(b)
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_char_u32 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        CharOp::apply2(
+          op,
+          &Char(b),
+          &U32(a)
+        ) ==
+        expected
+      )
+    };
+
+    match op {
+      CharOp::FromU32 => apply1_u32(char::from_u32(a).map(Char)),
+      CharOp::ToU32 => apply1_char(Some(U32(b.into()))),
+      CharOp::IsAlphabetic => apply1_char(Some(Bool(b.is_alphabetic()))),
+      CharOp::IsAlphanumeric => apply1_char(Some(Bool(b.is_alphanumeric()))),
+      CharOp::IsAscii => apply1_char(Some(Bool(b.is_ascii()))),
+      CharOp::IsAsciiAlphabetic => apply1_char(Some(Bool(b.is_ascii_alphabetic()))),
+      CharOp::IsAsciiAlphanumeric => apply1_char(Some(Bool(b.is_ascii_alphanumeric()))),
+      CharOp::IsAsciiControl => apply1_char(Some(Bool(b.is_ascii_control()))),
+      CharOp::IsAsciiDigit => apply1_char(Some(Bool(b.is_ascii_digit()))),
+      CharOp::IsAsciiGraphic => apply1_char(Some(Bool(b.is_ascii_graphic()))),
+      CharOp::IsAsciiHexDigit => apply1_char(Some(Bool(b.is_ascii_hexdigit()))),
+      CharOp::IsAsciiLowerCase => apply1_char(Some(Bool(b.is_ascii_lowercase()))),
+      CharOp::IsAsciiPunctuation => apply1_char(Some(Bool(b.is_ascii_punctuation()))),
+      CharOp::IsAsciiUpperCase => apply1_char(Some(Bool(b.is_ascii_uppercase()))),
+      CharOp::IsAsciiWhitespace => apply1_char(Some(Bool(b.is_ascii_whitespace()))),
+      CharOp::IsControl => apply1_char(Some(Bool(b.is_control()))),
+      CharOp::IsDigit => apply2_char_u32(
+        // TODO: Hardcoding the maximum radix here is probably bad, not sure how to do it differently though.
+        if a > 36 {
+          None
+        } else {
+          Some(Bool(b.is_digit(a)))
+        }
+      ),
+      CharOp::IsLowercase => apply1_char(Some(Bool(b.is_lowercase()))),
+      CharOp::IsNumeric => apply1_char(Some(Bool(b.is_numeric()))),
+      CharOp::IsUppercase => apply1_char(Some(Bool(b.is_uppercase()))),
+      CharOp::IsWhitespace => apply1_char(Some(Bool(b.is_whitespace()))),
+      CharOp::LenUTF8 => apply1_char(Some(Nat(b.len_utf8().into()))),
+      CharOp::LenUTF16 => apply1_char(Some(Nat(b.len_utf16().into()))),
+      CharOp::ToAsciiLowercase => apply1_char(Some(Char(b.to_ascii_lowercase()))),
+      CharOp::ToAsciiUppercase => apply1_char(Some(Char(b.to_ascii_uppercase()))),
+      CharOp::ToLowercase => apply1_char(Some(Text(b.to_lowercase().to_string().into()))),
+      CharOp::ToUppercase => apply1_char(Some(Text(b.to_uppercase().to_string().into()))),
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply_none_on_invalid(
+    op: CharOp,
+    a: Literal,
+    b: u32,
+    c: char,
+    test_arg_2: bool,
+  ) -> TestResult {
+    let test_apply1_none_on_invalid = |
+      valid_arg: Literal
+    | -> TestResult {
+      if mem::discriminant(&valid_arg) == mem::discriminant(&a) {
+        TestResult::discard()
+      } else {
+        TestResult::from_bool(
+          CharOp::apply1(
+            op,
+            &a
+          ) ==
+          None
+        )
+      }
+    };
+
+    let test_apply2_none_on_invalid = |
+      valid_arg: Literal,
+      a_: Literal,
+      b_: Literal
+    | -> TestResult {
+      let go = || TestResult::from_bool(
+        CharOp::apply2(
+          op,
+          &a_,
+          &b_
+        ) ==
+        None
+      );
+      if test_arg_2 {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&a_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      } else {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&b_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      }
+    };
+
+    match op {
+      // Arity 1, valid is U32.
+      CharOp::FromU32 => test_apply1_none_on_invalid(U32(b)),
+      // Arity 1, valid is Char.
+      CharOp::ToU32 |
+      CharOp::IsAlphabetic |
+      CharOp::IsAlphanumeric |
+      CharOp::IsAscii |
+      CharOp::IsAsciiAlphabetic |
+      CharOp::IsAsciiAlphanumeric |
+      CharOp::IsAsciiControl |
+      CharOp::IsAsciiDigit |
+      CharOp::IsAsciiGraphic |
+      CharOp::IsAsciiHexDigit |
+      CharOp::IsAsciiLowerCase |
+      CharOp::IsAsciiPunctuation |
+      CharOp::IsAsciiUpperCase |
+      CharOp::IsAsciiWhitespace |
+      CharOp::IsControl |
+      CharOp::IsLowercase |
+      CharOp::IsNumeric |
+      CharOp::IsUppercase |
+      CharOp::IsWhitespace |
+      CharOp::LenUTF8 |
+      CharOp::LenUTF16 |
+      CharOp::ToAsciiLowercase |
+      CharOp::ToAsciiUppercase |
+      CharOp::ToLowercase |
+      CharOp::ToUppercase => test_apply1_none_on_invalid(Char(c)),
+      // Arity 2, valid are Char on a and U32 on b.
+      CharOp::IsDigit => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          Char(c),
+          a,
+          U32(b)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          U32(b),
+          Char(c),
+          a
+        )
+      },
     }
   }
 

--- a/core/src/prim/i32.rs
+++ b/core/src/prim/i32.rs
@@ -13,6 +13,8 @@ use crate::{
   yatima,
 };
 
+use num_bigint::BigUint;
+
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum I32Op {
   Abs,
@@ -181,8 +183,8 @@ impl I32Op {
       Self::ToI64 => yatima!("∀ #I32 -> #I64"),
       Self::ToI128 => yatima!("∀ #I32 -> #I128"),
       Self::ToInt => yatima!("∀ #I32 -> #Int"),
-      Self::ToBits => yatima!("∀ #I32 -> #Bits"),
       Self::ToBytes => yatima!("∀ #I32 -> #Bytes"),
+      Self::ToBits => yatima!("∀ #I32 -> #Bits"),
     }
   }
 
@@ -311,16 +313,16 @@ impl I32Op {
       Self::ToI64 => 1,
       Self::ToI128 => 1,
       Self::ToInt => 1,
-      Self::ToBytes => 1,
       Self::ToBits => 1,
+      Self::ToBytes => 1,
     }
   }
 
   pub fn apply0(self) -> Option<Literal> {
     use Literal::*;
     match self {
-      Self::Max => Some(I16(i16::MAX)),
-      Self::Min => Some(I16(i16::MIN)),
+      Self::Max => Some(I32(i32::MAX)),
+      Self::Min => Some(I32(i32::MIN)),
       _ => None,
     }
   }
@@ -337,16 +339,19 @@ impl I32Op {
       (Self::ToU32, I32(x)) => u32::try_from(*x).ok().map(U32),
       (Self::ToU64, I32(x)) => u64::try_from(*x).ok().map(U64),
       (Self::ToU128, I32(x)) => u128::try_from(*x).ok().map(U128),
+      (Self::ToNat, I32(x)) => if x.is_negative() {
+        None
+      } else {
+        Some(Nat(BigUint::from(u64::try_from(*x).unwrap())))
+      },
       (Self::ToI8, I32(x)) => i8::try_from(*x).ok().map(I8),
       (Self::ToI16, I32(x)) => i16::try_from(*x).ok().map(I16),
       (Self::ToI64, I32(x)) => Some(I64((*x).into())),
       (Self::ToI128, I32(x)) => Some(I128((*x).into())),
       (Self::Not, I32(x)) => Some(I32(!x)),
       (Self::ToInt, I32(x)) => Some(Int((*x).into())),
+      (Self::ToBits, I32(x)) => Some(Bits(bits::bytes_to_bits(32, &x.to_be_bytes().into()))),
       (Self::ToBytes, I32(x)) => Some(Bytes(x.to_be_bytes().into())),
-      (Self::ToBits, I32(x)) => {
-        Some(Bits(bits::bytes_to_bits(32, &x.to_be_bytes().into())))
-      }
       _ => None,
     }
   }
@@ -365,8 +370,16 @@ impl I32Op {
       (Self::Add, I32(x), I32(y)) => Some(I32(x.wrapping_add(*y))),
       (Self::Sub, I32(x), I32(y)) => Some(I32(x.wrapping_sub(*y))),
       (Self::Mul, I32(x), I32(y)) => Some(I32(x.wrapping_mul(*y))),
-      (Self::Div, I32(x), I32(y)) => Some(I32(x.wrapping_div(*y))),
-      (Self::Mod, I32(x), I32(y)) => Some(I32(x.wrapping_rem(*y))),
+      (Self::Div, I32(x), I32(y)) => if *y == 0 {
+        None
+      } else {
+        Some(I32(x.wrapping_div(*y)))
+      },
+      (Self::Mod, I32(x), I32(y)) => if *y == 0 {
+        None
+      } else {
+        Some(I32(x.wrapping_rem(*y)))
+      },
       (Self::Pow, I32(x), U32(y)) => Some(I32(x.wrapping_pow(*y))),
       (Self::Shl, U32(x), I32(y)) => Some(I32(y.wrapping_shl(*x))),
       (Self::Shr, U32(x), I32(y)) => Some(I32(y.wrapping_shr(*x))),
@@ -389,12 +402,35 @@ pub mod tests {
   use quickcheck::{
     Arbitrary,
     Gen,
+    TestResult
   };
   use rand::Rng;
+  use Literal::{
+    I32,
+    U32,
+    Bool,
+    Nat,
+    Int,
+    Bits,
+    Bytes
+  };
+  use crate::prim::{
+    U8Op,
+    U16Op,
+    U32Op,
+    U64Op,
+    I8Op,
+    I16Op,
+    I64Op,
+  };
+  use std::{
+    convert::TryInto,
+    mem
+  };
   impl Arbitrary for I32Op {
     fn arbitrary(_g: &mut Gen) -> Self {
       let mut rng = rand::thread_rng();
-      let gen: u32 = rng.gen_range(0..37);
+      let gen: u32 = rng.gen_range(0..=35);
       match gen {
         0 => Self::Abs,
         1 => Self::Sgn,
@@ -425,15 +461,15 @@ pub mod tests {
         26 => Self::ToU16,
         27 => Self::ToU32,
         28 => Self::ToU64,
-        29 => Self::ToU128,
-        30 => Self::ToNat,
-        31 => Self::ToI8,
-        32 => Self::ToI16,
-        33 => Self::ToI64,
-        34 => Self::ToI128,
-        35 => Self::ToInt,
-        36 => Self::ToBytes,
+        29 => Self::ToNat,
+        30 => Self::ToI8,
+        31 => Self::ToI16,
+        32 => Self::ToI64,
+        33 => Self::ToInt,
+        34 => Self::ToBytes,
         _ => Self::ToBits,
+        // 29 => Self::ToU128,
+        // 34 => Self::ToI128,
       }
     }
   }
@@ -443,6 +479,317 @@ pub mod tests {
     match I32Op::from_ipld(&x.to_ipld()) {
       Ok(y) => x == y,
       _ => false,
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply(
+    op: I32Op,
+    a: i32,
+    b: i32,
+    c: u32
+  ) -> TestResult {
+    let apply0_go = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        I32Op::apply0(op) ==
+        expected
+      )
+    };
+
+    let apply1_i32 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        I32Op::apply1(
+          op,
+          &I32(a)
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_i32_i32 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        I32Op::apply2(
+          op,
+          &I32(a),
+          &I32(b)
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_i32_u32 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        I32Op::apply2(
+          op,
+          &I32(a),
+          &U32(c)
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_u32_i32 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        I32Op::apply2(
+          op,
+          &U32(c),
+          &I32(a)
+        ) ==
+        expected
+      )
+    };
+
+    let from_bool = TestResult::from_bool;
+
+    match op {
+      I32Op::Abs => apply1_i32(Some(U32(a.unsigned_abs()))),
+      I32Op::Sgn => apply1_i32(Some(Bool(a.is_positive()))),
+      I32Op::Max => apply0_go(Some(I32(i32::MAX))),
+      I32Op::Min => apply0_go(Some(I32(i32::MIN))),
+      I32Op::Eql => apply2_i32_i32(Some(Bool(a == b))),
+      I32Op::Lte => apply2_i32_i32(Some(Bool(a <= b))),
+      I32Op::Lth => apply2_i32_i32(Some(Bool(a < b))),
+      I32Op::Gth => apply2_i32_i32(Some(Bool(a > b))),
+      I32Op::Gte => apply2_i32_i32(Some(Bool(a >= b))),
+      I32Op::Not => apply1_i32(Some(I32(!a))),
+      I32Op::And => apply2_i32_i32(Some(I32(a & b))),
+      I32Op::Or => apply2_i32_i32(Some(I32(a | b))),
+      I32Op::Xor => apply2_i32_i32(Some(I32(a ^ b))),
+      I32Op::Add => apply2_i32_i32(Some(I32(a.wrapping_add(b)))),
+      I32Op::Sub => apply2_i32_i32(Some(I32(a.wrapping_sub(b)))),
+      I32Op::Mul => apply2_i32_i32(Some(I32(a.wrapping_mul(b)))),
+      I32Op::Div => apply2_i32_i32(
+        if b == 0 {
+          None
+        } else {
+          Some(I32(a.wrapping_div(b)))
+        }
+      ),
+      I32Op::Mod => apply2_i32_i32(
+        if b == 0 {
+          None
+        } else {
+          Some(I32(a.wrapping_rem(b)))
+        }
+      ),
+      I32Op::Pow => apply2_i32_u32(Some(I32(a.wrapping_pow(c)))),
+      I32Op::Shl => apply2_u32_i32(Some(I32(a.wrapping_shl(c)))),
+      I32Op::Shr => apply2_u32_i32(Some(I32(a.wrapping_shr(c)))),
+      I32Op::Rol => apply2_u32_i32(Some(I32(a.rotate_left(c)))),
+      I32Op::Ror => apply2_u32_i32(Some(I32(a.rotate_right(c)))),
+      I32Op::CountZeros => apply1_i32(Some(U32(a.count_zeros()))),
+      I32Op::CountOnes => apply1_i32(Some(U32(a.count_ones()))),
+      I32Op::ToU8 => from_bool(
+        if a < u8::MIN.into() || a > u8::MAX.into() {
+          I32Op::apply1(op, &I32(a)) == None
+        } else {
+          U8Op::apply1(
+            U8Op::ToI32,
+            &I32Op::apply1(op, &I32(a)).unwrap()
+          ) == Some(I32(a))
+        }
+      ),
+      I32Op::ToU16 => from_bool(
+        if a < u16::MIN.into() || a > u16::MAX.into() {
+          I32Op::apply1(op, &I32(a)) == None
+        } else {
+          U16Op::apply1(
+            U16Op::ToI32,
+            &I32Op::apply1(op, &I32(a)).unwrap()
+          ) == Some(I32(a))
+        }
+      ),
+      I32Op::ToU32 => from_bool(
+        if a < u32::MIN.try_into().unwrap() {
+          I32Op::apply1(op, &I32(a)) == None
+        } else {
+          U32Op::apply1(
+            U32Op::ToI32,
+            &I32Op::apply1(op, &I32(a)).unwrap()
+          ) == Some(I32(a))
+        }
+      ),
+      I32Op::ToU64 => from_bool(
+        if a < u64::MIN.try_into().unwrap() {
+          I32Op::apply1(op, &I32(a)) == None
+        } else {
+          U64Op::apply1(
+            U64Op::ToI32,
+            &I32Op::apply1(op, &I32(a)).unwrap()
+          ) == Some(I32(a))
+        }
+      ),
+      I32Op::ToU128 => TestResult::discard(),
+      I32Op::ToNat => if a.is_negative() {
+        apply1_i32(None)
+      } else {
+        apply1_i32(Some(Nat(BigUint::from(u64::try_from(a).unwrap()))))
+      },
+      I32Op::ToI8 => from_bool(
+        if a < i8::MIN.into() || a > i8::MAX.into() {
+          I32Op::apply1(op, &I32(a)) == None
+        } else {
+          I8Op::apply1(
+            I8Op::ToI32,
+            &I32Op::apply1(op, &I32(a)).unwrap()
+          ) == Some(I32(a))
+        }
+      ),
+      I32Op::ToI16 => from_bool(
+        if a < i16::MIN.into() || a > i16::MAX.into() {
+          I32Op::apply1(op, &I32(a)) == None
+        } else {
+          I16Op::apply1(
+            I16Op::ToI32,
+            &I32Op::apply1(op, &I32(a)).unwrap()
+          ) == Some(I32(a))
+        }
+      ),
+      I32Op::ToI64 => from_bool(
+        I64Op::apply1(
+          I64Op::ToI32,
+          &I32Op::apply1(op, &I32(a)).unwrap()
+        ) == Some(I32(a))
+      ),
+      I32Op::ToI128 => TestResult::discard(),
+      I32Op::ToInt => apply1_i32(Some(Int(a.into()))),
+      I32Op::ToBits => apply1_i32(Some(Bits(bits::bytes_to_bits(32, &a.to_be_bytes().into())))),
+      I32Op::ToBytes => apply1_i32(Some(Bytes(a.to_be_bytes().into()))),
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply_none_on_invalid(
+    op: I32Op,
+    a: Literal,
+    b: i32,
+    c: u32,
+    test_arg_2: bool,
+  ) -> TestResult {
+    let test_apply1_none_on_invalid = |
+      valid_arg: Literal
+    | -> TestResult {
+      if mem::discriminant(&valid_arg) == mem::discriminant(&a) {
+        TestResult::discard()
+      } else {
+        TestResult::from_bool(
+          I32Op::apply1(
+            op,
+            &a
+          ) ==
+          None
+        )
+      }
+    };
+
+    let test_apply2_none_on_invalid = |
+      valid_arg: Literal,
+      a_: Literal,
+      b_: Literal
+    | -> TestResult {
+      let go = || TestResult::from_bool(
+        I32Op::apply2(
+          op,
+          &a_,
+          &b_
+        ) ==
+        None
+      );
+      if test_arg_2 {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&a_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      } else {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&b_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      }
+    };
+
+    match op {
+      // Arity 0.
+      I32Op::Max |
+      I32Op::Min => TestResult::discard(),
+      // Arity 1, valid is I32.
+      I32Op::Abs |
+      I32Op::Sgn |
+      I32Op::Not |
+      I32Op::CountZeros |
+      I32Op::CountOnes |
+      I32Op::ToU8 |
+      I32Op::ToU16 |
+      I32Op::ToU32 |
+      I32Op::ToU64 |
+      I32Op::ToU128 |
+      I32Op::ToNat |
+      I32Op::ToI8 |
+      I32Op::ToI16 |
+      I32Op::ToI64 |
+      I32Op::ToI128 |
+      I32Op::ToInt |
+      I32Op::ToBytes |
+      I32Op::ToBits => test_apply1_none_on_invalid(I32(b)),
+      // Arity 2, valid are I32 on a and b.
+      I32Op::Eql |
+      I32Op::Lte |
+      I32Op::Lth |
+      I32Op::Gth |
+      I32Op::Gte |
+      I32Op::And |
+      I32Op::Or |
+      I32Op::Xor |
+      I32Op::Add |
+      I32Op::Sub |
+      I32Op::Mul |
+      I32Op::Div |
+      I32Op::Mod => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          I32(b),
+          a,
+          I32(b)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          I32(b),
+          I32(b),
+          a
+        )
+      },
+      // Arity 2, valid are I32 on a and U32 on b.
+      I32Op::Pow => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          I32(b),
+          a,
+          U32(c)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          U32(c),
+          I32(b),
+          a
+        )
+      },
+      // Arity 2, valid are U32 on a and I32 on b.
+      I32Op::Shl |
+      I32Op::Shr |
+      I32Op::Rol |
+      I32Op::Ror => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          U32(c),
+          a,
+          I32(b)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          I32(b),
+          U32(c),
+          a
+        )
+      },
     }
   }
 }

--- a/core/src/prim/i8.rs
+++ b/core/src/prim/i8.rs
@@ -13,6 +13,8 @@ use crate::{
   yatima,
 };
 
+use num_bigint::BigUint;
+
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum I8Op {
   Abs,
@@ -51,8 +53,8 @@ pub enum I8Op {
   ToI64,
   ToI128,
   ToInt,
-  ToBytes,
   ToBits,
+  ToBytes,
 }
 
 impl I8Op {
@@ -94,8 +96,8 @@ impl I8Op {
       Self::ToI64 => "to_I64".to_owned(),
       Self::ToI128 => "to_I128".to_owned(),
       Self::ToInt => "to_Int".to_owned(),
-      Self::ToBytes => "to_Bytes".to_owned(),
       Self::ToBits => "to_Bits".to_owned(),
+      Self::ToBytes => "to_Bytes".to_owned(),
     }
   }
 
@@ -137,8 +139,8 @@ impl I8Op {
       "to_I64" => Some(Self::ToI64),
       "to_I128" => Some(Self::ToI128),
       "to_Int" => Some(Self::ToInt),
-      "to_Bytes" => Some(Self::ToBytes),
       "to_Bits" => Some(Self::ToBits),
+      "to_Bytes" => Some(Self::ToBytes),
       _ => None,
     }
   }
@@ -181,8 +183,8 @@ impl I8Op {
       Self::ToI64 => yatima!("∀ #I8 -> #I64"),
       Self::ToI128 => yatima!("∀ #I8 -> #I128"),
       Self::ToInt => yatima!("∀ #I8 -> #Int"),
-      Self::ToBytes => yatima!("∀ #I8 -> #Bytes"),
       Self::ToBits => yatima!("∀ #I8 -> #Bits"),
+      Self::ToBytes => yatima!("∀ #I8 -> #Bytes"),
     }
   }
 
@@ -311,8 +313,8 @@ impl I8Op {
       Self::ToI64 => 1,
       Self::ToI128 => 1,
       Self::ToInt => 1,
-      Self::ToBytes => 1,
       Self::ToBits => 1,
+      Self::ToBytes => 1,
     }
   }
 
@@ -337,16 +339,19 @@ impl I8Op {
       (Self::ToU32, I8(x)) => u32::try_from(*x).ok().map(U32),
       (Self::ToU64, I8(x)) => u64::try_from(*x).ok().map(U64),
       (Self::ToU128, I8(x)) => u128::try_from(*x).ok().map(U128),
+      (Self::ToNat, I8(x)) => if x.is_negative() {
+        None
+      } else {
+        Some(Nat(BigUint::from(u64::try_from(*x).unwrap())))
+      },
       (Self::ToI16, I8(x)) => Some(I16((*x).into())),
       (Self::ToI32, I8(x)) => Some(I32((*x).into())),
       (Self::ToI64, I8(x)) => Some(I64((*x).into())),
       (Self::ToI128, I8(x)) => Some(I128((*x).into())),
       (Self::Not, I8(x)) => Some(I8(!x)),
       (Self::ToInt, I8(x)) => Some(Int((*x).into())),
+      (Self::ToBits, I8(x)) => Some(Bits(bits::bytes_to_bits(8, &x.to_be_bytes().into()))),
       (Self::ToBytes, I8(x)) => Some(Bytes(x.to_be_bytes().into())),
-      (Self::ToBits, I8(x)) => {
-        Some(Bits(bits::bytes_to_bits(8, &x.to_be_bytes().into())))
-      }
       _ => None,
     }
   }
@@ -365,8 +370,16 @@ impl I8Op {
       (Self::Add, I8(x), I8(y)) => Some(I8(x.wrapping_add(*y))),
       (Self::Sub, I8(x), I8(y)) => Some(I8(x.wrapping_sub(*y))),
       (Self::Mul, I8(x), I8(y)) => Some(I8(x.wrapping_mul(*y))),
-      (Self::Div, I8(x), I8(y)) => Some(I8(x.wrapping_div(*y))),
-      (Self::Mod, I8(x), I8(y)) => Some(I8(x.wrapping_rem(*y))),
+      (Self::Div, I8(x), I8(y)) => if *y == 0 {
+        None
+      } else {
+        Some(I8(x.wrapping_div(*y)))
+      },
+      (Self::Mod, I8(x), I8(y)) => if *y == 0 {
+        None
+      } else {
+        Some(I8(x.wrapping_rem(*y)))
+      },
       (Self::Pow, I8(x), U32(y)) => Some(I8(x.wrapping_pow(*y))),
       (Self::Shl, U32(x), I8(y)) => Some(I8(y.wrapping_shl(*x))),
       (Self::Shr, U32(x), I8(y)) => Some(I8(y.wrapping_shr(*x))),
@@ -389,12 +402,37 @@ pub mod tests {
   use quickcheck::{
     Arbitrary,
     Gen,
+    TestResult
   };
   use rand::Rng;
+  use Literal::{
+    I8,
+    U8,
+    Bool,
+    Nat,
+    Int,
+    Bits,
+    Bytes,
+    U32
+  };
+  use crate::prim::{
+    U8Op,
+    U16Op,
+    U32Op,
+    U64Op,
+    I16Op,
+    I32Op,
+    I64Op,
+  };
+  use std::{
+    convert::TryInto,
+    mem
+  };
+  use num_bigint::BigUint;
   impl Arbitrary for I8Op {
     fn arbitrary(_g: &mut Gen) -> Self {
       let mut rng = rand::thread_rng();
-      let gen: u32 = rng.gen_range(0..37);
+      let gen: u32 = rng.gen_range(0..=35);
       match gen {
         0 => Self::Abs,
         1 => Self::Sgn,
@@ -425,15 +463,15 @@ pub mod tests {
         26 => Self::ToU16,
         27 => Self::ToU32,
         28 => Self::ToU64,
-        29 => Self::ToU128,
-        30 => Self::ToNat,
-        31 => Self::ToI16,
-        32 => Self::ToI32,
-        33 => Self::ToI64,
-        34 => Self::ToI128,
-        35 => Self::ToInt,
-        36 => Self::ToBytes,
-        _ => Self::ToBits,
+        29 => Self::ToNat,
+        30 => Self::ToI16,
+        31 => Self::ToI32,
+        32 => Self::ToI64,
+        33 => Self::ToInt,
+        34 => Self::ToBits,
+        _ => Self::ToBytes,
+        // 29 => Self::ToU128,
+        // 34 => Self::ToI128,
       }
     }
   }
@@ -443,6 +481,309 @@ pub mod tests {
     match I8Op::from_ipld(&x.to_ipld()) {
       Ok(y) => x == y,
       _ => false,
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply(
+    op: I8Op,
+    a: i8,
+    b: i8,
+    c: u32
+  ) -> TestResult {
+    let apply0_go = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        I8Op::apply0(op) ==
+        expected
+      )
+    };
+
+    let apply1_i8 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        I8Op::apply1(
+          op,
+          &I8(a)
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_i8_i8 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        I8Op::apply2(
+          op,
+          &I8(a),
+          &I8(b)
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_i8_u32 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        I8Op::apply2(
+          op,
+          &I8(a),
+          &U32(c)
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_u32_i8 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        I8Op::apply2(
+          op,
+          &U32(c),
+          &I8(a)
+        ) ==
+        expected
+      )
+    };
+
+    let from_bool = TestResult::from_bool;
+
+    match op {
+      I8Op::Abs => apply1_i8(Some(U8(a.unsigned_abs()))),
+      I8Op::Sgn => apply1_i8(Some(Bool(a.is_positive()))),
+      I8Op::Max => apply0_go(Some(I8(i8::MAX))),
+      I8Op::Min => apply0_go(Some(I8(i8::MIN))),
+      I8Op::Eql => apply2_i8_i8(Some(Bool(a == b))),
+      I8Op::Lte => apply2_i8_i8(Some(Bool(a <= b))),
+      I8Op::Lth => apply2_i8_i8(Some(Bool(a < b))),
+      I8Op::Gth => apply2_i8_i8(Some(Bool(a > b))),
+      I8Op::Gte => apply2_i8_i8(Some(Bool(a >= b))),
+      I8Op::Not => apply1_i8(Some(I8(!a))),
+      I8Op::And => apply2_i8_i8(Some(I8(a & b))),
+      I8Op::Or => apply2_i8_i8(Some(I8(a | b))),
+      I8Op::Xor => apply2_i8_i8(Some(I8(a ^ b))),
+      I8Op::Add => apply2_i8_i8(Some(I8(a.wrapping_add(b)))),
+      I8Op::Sub => apply2_i8_i8(Some(I8(a.wrapping_sub(b)))),
+      I8Op::Mul => apply2_i8_i8(Some(I8(a.wrapping_mul(b)))),
+      I8Op::Div => apply2_i8_i8(
+        if b == 0 {
+          None
+        } else {
+          Some(I8(a.wrapping_div(b)))
+        }
+      ),
+      I8Op::Mod => apply2_i8_i8(
+        if b == 0 {
+          None
+        } else {
+          Some(I8(a.wrapping_rem(b)))
+        }
+      ),
+      I8Op::Pow => apply2_i8_u32(Some(I8(a.wrapping_pow(c)))),
+      I8Op::Shl => apply2_u32_i8(Some(I8(a.wrapping_shl(c)))),
+      I8Op::Shr => apply2_u32_i8(Some(I8(a.wrapping_shr(c)))),
+      I8Op::Rol => apply2_u32_i8(Some(I8(a.rotate_left(c)))),
+      I8Op::Ror => apply2_u32_i8(Some(I8(a.rotate_right(c)))),
+      I8Op::CountZeros => apply1_i8(Some(U32(a.count_zeros()))),
+      I8Op::CountOnes => apply1_i8(Some(U32(a.count_ones()))),
+      I8Op::ToU8 => from_bool(
+        if a < u8::MIN.try_into().unwrap() {
+          I8Op::apply1(op, &I8(a)) == None
+        } else {
+          U8Op::apply1(
+            U8Op::ToI8,
+            &I8Op::apply1(op, &I8(a)).unwrap()
+          ) == Some(I8(a))
+        }
+      ),
+      I8Op::ToU16 => from_bool(
+        if a < u16::MIN.try_into().unwrap() {
+          I8Op::apply1(op, &I8(a)) == None
+        } else {
+          U16Op::apply1(
+            U16Op::ToI8,
+            &I8Op::apply1(op, &I8(a)).unwrap()
+          ) == Some(I8(a))
+        }
+      ),
+      I8Op::ToU32 => from_bool(
+        if a < u32::MIN.try_into().unwrap() {
+          I8Op::apply1(op, &I8(a)) == None
+        } else {
+          U32Op::apply1(
+            U32Op::ToI8,
+            &I8Op::apply1(op, &I8(a)).unwrap()
+          ) == Some(I8(a))
+        }
+      ),
+      I8Op::ToU64 => from_bool(
+        if a < u64::MIN.try_into().unwrap() {
+          I8Op::apply1(op, &I8(a)) == None
+        } else {
+          U64Op::apply1(
+            U64Op::ToI8,
+            &I8Op::apply1(op, &I8(a)).unwrap()
+          ) == Some(I8(a))
+        }
+      ),
+      I8Op::ToU128 => TestResult::discard(),
+      I8Op::ToNat => if a.is_negative() {
+        apply1_i8(None)
+      } else {
+        apply1_i8(Some(Nat(BigUint::from(u64::try_from(a).unwrap()))))
+      },
+      I8Op::ToI16 => from_bool(
+        I16Op::apply1(
+          I16Op::ToI8,
+          &I8Op::apply1(op, &I8(a)).unwrap()
+        ) == Some(I8(a))
+      ),
+      I8Op::ToI32 => from_bool(
+        I32Op::apply1(
+          I32Op::ToI8,
+          &I8Op::apply1(op, &I8(a)).unwrap()
+        ) == Some(I8(a))
+      ),
+      I8Op::ToI64 => from_bool(
+        I64Op::apply1(
+          I64Op::ToI8,
+          &I8Op::apply1(op, &I8(a)).unwrap()
+        ) == Some(I8(a))
+      ),
+      I8Op::ToI128 => TestResult::discard(),
+      I8Op::ToInt => apply1_i8(Some(Int(a.into()))),
+      I8Op::ToBits => apply1_i8(Some(Bits(bits::bytes_to_bits(8, &a.to_be_bytes().into())))),
+      I8Op::ToBytes => apply1_i8(Some(Bytes(a.to_be_bytes().into()))),
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply_none_on_invalid(
+    op: I8Op,
+    a: Literal,
+    b: i8,
+    c: u32,
+    test_arg_2: bool,
+  ) -> TestResult {
+    let test_apply1_none_on_invalid = |
+      valid_arg: Literal
+    | -> TestResult {
+      if mem::discriminant(&valid_arg) == mem::discriminant(&a) {
+        TestResult::discard()
+      } else {
+        TestResult::from_bool(
+          I8Op::apply1(
+            op,
+            &a
+          ) ==
+          None
+        )
+      }
+    };
+
+    let test_apply2_none_on_invalid = |
+      valid_arg: Literal,
+      a_: Literal,
+      b_: Literal
+    | -> TestResult {
+      let go = || TestResult::from_bool(
+        I8Op::apply2(
+          op,
+          &a_,
+          &b_
+        ) ==
+        None
+      );
+      if test_arg_2 {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&a_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      } else {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&b_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      }
+    };
+
+    match op {
+      // Arity 0.
+      I8Op::Max |
+      I8Op::Min => TestResult::discard(),
+      // Arity 1, valid is I8.
+      I8Op::Abs |
+      I8Op::Sgn |
+      I8Op::Not |
+      I8Op::CountZeros |
+      I8Op::CountOnes |
+      I8Op::ToU8 |
+      I8Op::ToU16 |
+      I8Op::ToU32 |
+      I8Op::ToU64 |
+      I8Op::ToU128 |
+      I8Op::ToNat |
+      I8Op::ToI16 |
+      I8Op::ToI32 |
+      I8Op::ToI64 |
+      I8Op::ToI128 |
+      I8Op::ToInt |
+      I8Op::ToBytes |
+      I8Op::ToBits => test_apply1_none_on_invalid(I8(b)),
+      // Arity 2, valid are I8 on a and b.
+      I8Op::Eql |
+      I8Op::Lte |
+      I8Op::Lth |
+      I8Op::Gth |
+      I8Op::Gte |
+      I8Op::And |
+      I8Op::Or |
+      I8Op::Xor |
+      I8Op::Add |
+      I8Op::Sub |
+      I8Op::Mul |
+      I8Op::Div |
+      I8Op::Mod => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          I8(b),
+          a,
+          I8(b)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          I8(b),
+          I8(b),
+          a
+        )
+      },
+      // Arity 2, valid are I8 on a and U32 on b.
+      I8Op::Pow => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          I8(b),
+          a,
+          U32(c)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          U32(c),
+          I8(b),
+          a
+        )
+      },
+      // Arity 2, valid are U32 on a and I8 on b.
+      I8Op::Shl |
+      I8Op::Shr |
+      I8Op::Rol |
+      I8Op::Ror => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          U32(c),
+          a,
+          I8(b)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          I8(b),
+          U32(c),
+          a
+        )
+      },
     }
   }
 }

--- a/core/src/prim/int.rs
+++ b/core/src/prim/int.rs
@@ -144,11 +144,7 @@ impl IntOp {
   pub fn apply1(self, x: &Literal) -> Option<Literal> {
     use Literal::*;
     match (self, x) {
-      (Self::Sgn, Int(x)) => match x.sign() {
-        Sign::NoSign => Some(Int(BigInt::from(0i64))),
-        Sign::Plus => Some(Int(BigInt::from(1i64))),
-        Sign::Minus => Some(Int(BigInt::from(-1i64))),
-      },
+      (Self::Sgn, Int(x)) => Some(Bool(matches!(x.sign(), Sign::Plus))),
       (Self::Abs, Int(x)) => Some(Nat(x.clone().into_parts().1)),
       _ => None,
     }
@@ -160,9 +156,15 @@ impl IntOp {
     let ff = Bool(false);
     let ite = |c| if c { tt } else { ff };
     match (self, x, y) {
+      (Self::New, Bool(x), Nat(y)) => Some(Int(if *x {
+        BigInt::from(y.clone())
+      } else {
+        BigInt::from(y.clone()) * -1
+      })),
       (Self::Eql, Int(x), Int(y)) => Some(ite(x == y)),
-      (Self::Lth, Int(x), Int(y)) => Some(ite(x < y)),
       (Self::Lte, Int(x), Int(y)) => Some(ite(x <= y)),
+      (Self::Lth, Int(x), Int(y)) => Some(ite(x < y)),
+      (Self::Gte, Int(x), Int(y)) => Some(ite(x >= y)),
       (Self::Gth, Int(x), Int(y)) => Some(ite(x > y)),
       (Self::Add, Int(x), Int(y)) => Some(Int(x + y)),
       (Self::Sub, Int(x), Int(y)) => Some(Int(x - y)),
@@ -186,12 +188,23 @@ pub mod tests {
   use quickcheck::{
     Arbitrary,
     Gen,
+    TestResult
   };
   use rand::Rng;
+  use Literal::{
+    Int,
+    Bool,
+    Nat
+  };
+  use num_bigint::{
+    BigInt,
+    BigUint
+  };
+  use std::mem;
   impl Arbitrary for IntOp {
     fn arbitrary(_g: &mut Gen) -> Self {
       let mut rng = rand::thread_rng();
-      let gen: u32 = rng.gen_range(0..12);
+      let gen: u32 = rng.gen_range(0..=12);
       match gen {
         0 => Self::New,
         1 => Self::Sgn,
@@ -215,6 +228,164 @@ pub mod tests {
     match IntOp::from_ipld(&x.to_ipld()) {
       Ok(y) => x == y,
       _ => false,
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply(
+    op: IntOp,
+    a: i64,
+    b: i64,
+    c: bool,
+    d: u64
+  ) -> TestResult {
+    let big_int = BigInt::from;
+    let big_uint = BigUint::from;
+    let apply1_int = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        IntOp::apply1(
+          op,
+          &Int(big_int(a))
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_bool_nat = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        IntOp::apply2(
+          op,
+          &Bool(c),
+          &Nat(big_uint(d))
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_int_int = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        IntOp::apply2(
+          op,
+          &Int(big_int(a)),
+          &Int(big_int(b))
+        ) ==
+        expected
+      )
+    };
+
+    match op {
+      IntOp::New => apply2_bool_nat(Some(Int(if c {
+        BigInt::from(d)
+      } else {
+        BigInt::from(d) * -1
+      }))),
+      IntOp::Sgn => apply1_int(Some(Bool(a.is_positive()))),
+      IntOp::Abs => apply1_int(Some(Nat(BigUint::from(a.unsigned_abs())))),
+      IntOp::Eql => apply2_int_int(Some(Bool(a == b))),
+      IntOp::Lte => apply2_int_int(Some(Bool(a <= b))),
+      IntOp::Lth => apply2_int_int(Some(Bool(a < b))),
+      IntOp::Gte => apply2_int_int(Some(Bool(a >= b))),
+      IntOp::Gth => apply2_int_int(Some(Bool(a > b))),
+      IntOp::Add => apply2_int_int(Some(Int(big_int(a) + big_int(b)))),
+      IntOp::Sub => apply2_int_int(Some(Int(big_int(a) - big_int(b)))),
+      IntOp::Mul => apply2_int_int(Some(Int(big_int(a) * big_int(b)))),
+      IntOp::Div => apply2_int_int(
+          if b != 0 {
+          Some(Int(big_int(a) / big_int(b)))
+        } else {
+          None
+        }
+      ),
+      IntOp::Mod => apply2_int_int(
+          if b != 0 {
+          Some(Int(big_int(a) % big_int(b)))
+        } else {
+          None
+        }
+      ),
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply_none_on_invalid(
+    op: IntOp,
+    a: Literal,
+    b: i64,
+    test_arg_2: bool,
+  ) -> TestResult {
+    let big = BigInt::from;
+    let test_apply1_none_on_invalid = |
+      valid_arg: Literal
+    | -> TestResult {
+      if mem::discriminant(&valid_arg) == mem::discriminant(&a) {
+        TestResult::discard()
+      } else {
+        TestResult::from_bool(
+          IntOp::apply1(
+            op,
+            &a
+          ) ==
+          None
+        )
+      }
+    };
+
+    let test_apply2_none_on_invalid = |
+      valid_arg: Literal,
+      a_: Literal,
+      b_: Literal
+    | -> TestResult {
+      let go = || TestResult::from_bool(
+        IntOp::apply2(
+          op,
+          &a_,
+          &b_
+        ) ==
+        None
+      );
+      if test_arg_2 {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&a_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      } else {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&b_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      }
+    };
+
+    match op {
+      // Arity 1, valid is Int.
+      IntOp::Sgn | 
+      IntOp::Abs => test_apply1_none_on_invalid(Int(big(b))),
+      // Arity 2, valid are Int on a and b.
+      IntOp::New |
+      IntOp::Eql |
+      IntOp::Lte |
+      IntOp::Lth |
+      IntOp::Gte |
+      IntOp::Gth |
+      IntOp::Add |
+      IntOp::Sub |
+      IntOp::Mul |
+      IntOp::Div |
+      IntOp::Mod => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          Int(big(b)),
+          a,
+          Int(big(b))
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          Int(big(b)),
+          Int(big(b)),
+          a,
+        )
+      },
     }
   }
 

--- a/core/src/prim/nat.rs
+++ b/core/src/prim/nat.rs
@@ -154,8 +154,9 @@ impl NatOp {
     let ite = |c| if c { tt } else { ff };
     match (self, x, y) {
       (Self::Eql, Nat(x), Nat(y)) => Some(ite(x == y)),
-      (Self::Lth, Nat(x), Nat(y)) => Some(ite(x < y)),
       (Self::Lte, Nat(x), Nat(y)) => Some(ite(x <= y)),
+      (Self::Lth, Nat(x), Nat(y)) => Some(ite(x < y)),
+      (Self::Gte, Nat(x), Nat(y)) => Some(ite(x >= y)),
       (Self::Gth, Nat(x), Nat(y)) => Some(ite(x > y)),
       (Self::Add, Nat(x), Nat(y)) => Some(Nat(x + y)),
       (Self::Sub, Nat(x), Nat(y)) if x >= y => Some(Nat(x - y)),
@@ -179,12 +180,19 @@ pub mod tests {
   use quickcheck::{
     Arbitrary,
     Gen,
+    TestResult
   };
   use rand::Rng;
+  use Literal::{
+    Nat,
+    Bool
+  };
+  use num_bigint::BigUint;
+  use std::mem;
   impl Arbitrary for NatOp {
     fn arbitrary(_g: &mut Gen) -> Self {
       let mut rng = rand::thread_rng();
-      let gen: u32 = rng.gen_range(0..11);
+      let gen: u32 = rng.gen_range(0..=11);
       match gen {
         0 => Self::Suc,
         1 => Self::Pre,
@@ -207,6 +215,154 @@ pub mod tests {
     match NatOp::from_ipld(&x.to_ipld()) {
       Ok(y) => x == y,
       _ => false,
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply(
+    op: NatOp,
+    a: u64,
+    b: u64
+  ) -> TestResult {
+    let big = BigUint::from;
+    let apply1_nat = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        NatOp::apply1(
+          op,
+          &Nat(big(a))
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_nat_nat = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        NatOp::apply2(
+          op,
+          &Nat(big(a)),
+          &Nat(big(b))
+        ) ==
+        expected
+      )
+    };
+
+    match op {
+      NatOp::Suc => apply1_nat(Some(Nat(big(a) + big(1)))),
+      NatOp::Pre => apply1_nat(Some(Nat(big(if a == 0 {
+        a
+      } else {
+        a - 1
+      })))),
+      NatOp::Eql => apply2_nat_nat(Some(Bool(a == b))),
+      NatOp::Lte => apply2_nat_nat(Some(Bool(a <= b))),
+      NatOp::Lth => apply2_nat_nat(Some(Bool(a < b))),
+      NatOp::Gte => apply2_nat_nat(Some(Bool(a >= b))),
+      NatOp::Gth => apply2_nat_nat(Some(Bool(a > b))),
+      NatOp::Add => apply2_nat_nat(Some(Nat(big(a) + big(b)))),
+      NatOp::Sub => apply2_nat_nat(
+          if a >= b {
+          Some(Nat(big(a - b)))
+        } else {
+          None
+        }
+      ),
+      NatOp::Mul => apply2_nat_nat(Some(Nat(big(a) * big(b)))),
+      NatOp::Div => apply2_nat_nat(
+          if b != 0 {
+          Some(Nat(big(a / b)))
+        } else {
+          None
+        }
+      ),
+      NatOp::Mod => apply2_nat_nat(
+          if b != 0 {
+          Some(Nat(big(a % b)))
+        } else {
+          None
+        }
+      ),
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply_none_on_invalid(
+    op: NatOp,
+    a: Literal,
+    b: u64,
+    test_arg_2: bool,
+  ) -> TestResult {
+    let big = BigUint::from;
+    let test_apply1_none_on_invalid = |
+      valid_arg: Literal
+    | -> TestResult {
+      if mem::discriminant(&valid_arg) == mem::discriminant(&a) {
+        TestResult::discard()
+      } else {
+        TestResult::from_bool(
+          NatOp::apply1(
+            op,
+            &a
+          ) ==
+          None
+        )
+      }
+    };
+
+    let test_apply2_none_on_invalid = |
+      valid_arg: Literal,
+      a_: Literal,
+      b_: Literal
+    | -> TestResult {
+      let go = || TestResult::from_bool(
+        NatOp::apply2(
+          op,
+          &a_,
+          &b_
+        ) ==
+        None
+      );
+      if test_arg_2 {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&a_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      } else {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&b_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      }
+    };
+
+    match op {
+      // Arity 1, valid is Nat.
+      NatOp::Suc | 
+      NatOp::Pre => test_apply1_none_on_invalid(Nat(big(b))),
+      // Arity 2, valid are Nat on a and b.
+      NatOp::Eql |
+      NatOp::Lte |
+      NatOp::Lth |
+      NatOp::Gte |
+      NatOp::Gth |
+      NatOp::Add |
+      NatOp::Sub |
+      NatOp::Mul |
+      NatOp::Div |
+      NatOp::Mod => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          Nat(big(b)),
+          a,
+          Nat(big(b))
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          Nat(big(b)),
+          Nat(big(b)),
+          a
+        )
+      },
     }
   }
 

--- a/core/src/prim/text.rs
+++ b/core/src/prim/text.rs
@@ -226,6 +226,7 @@ impl TextOp {
       (Self::LenChars, Text(xs)) => Some(Nat(xs.len_chars().into())),
       (Self::LenBytes, Text(xs)) => Some(Nat(xs.len_bytes().into())),
       (Self::LenLines, Text(xs)) => Some(Nat(xs.len_lines().into())),
+      (Self::ToBytes, Text(xs)) => Some(Bytes(xs.bytes().collect::<Vec<u8>>())),
       _ => None,
     }
   }
@@ -266,7 +267,7 @@ impl TextOp {
       }
       (Self::Line, Nat(idx), Text(ys)) => {
         let idx: usize = idx.clone().try_into().ok()?;
-        if idx < ys.len_chars() {
+        if idx < ys.len_lines() {
           Some(Text(ys.line(idx).into()))
         }
         else {
@@ -372,7 +373,7 @@ pub fn safe_remove(from: &BigUint, upto: &BigUint, mut xs: Rope) -> Rope {
   let upto = usize::try_from(upto);
   let len = xs.len_chars();
   match (from, upto) {
-    (Ok(from), Ok(upto)) if (from <= len) && (upto <= len) => {
+    (Ok(from), Ok(upto)) if (from <= len) && (upto <= len) && (upto >= from) => {
       xs.remove(from..upto);
       xs
     }
@@ -416,12 +417,24 @@ pub mod tests {
   use quickcheck::{
     Arbitrary,
     Gen,
+    TestResult
   };
   use rand::Rng;
+  use Literal::{
+    Text,
+    Char,
+    Nat,
+    Bool,
+    U8,
+    Bytes
+  };
+  use crate::prim::tests::TestArg3;
+  use std::mem;
+  use core::fmt::Debug;
   impl Arbitrary for TextOp {
     fn arbitrary(_g: &mut Gen) -> Self {
       let mut rng = rand::thread_rng();
-      let gen: u32 = rng.gen_range(0..11);
+      let gen: u32 = rng.gen_range(0..=23);
       match gen {
         0 => Self::Cons,
         1 => Self::LenChars,
@@ -441,10 +454,11 @@ pub mod tests {
         15 => Self::Byte,
         16 => Self::Line,
         17 => Self::CharAtByte,
-        18 => Self::LineAtByte,
-        19 => Self::LineAtChar,
-        20 => Self::LineStartChar,
-        21 => Self::LineStartByte,
+        18 => Self::ByteAtChar,
+        19 => Self::LineAtByte,
+        20 => Self::LineAtChar,
+        21 => Self::LineStartChar,
+        22 => Self::LineStartByte,
         _ => Self::ToBytes,
       }
     }
@@ -476,5 +490,427 @@ pub mod tests {
     assert_eq!(res, (Rope::from_str("foo"), Rope::from_str("")));
     let res = safe_split(&u128::MAX.into(), rope.clone());
     assert_eq!(res, (Rope::from_str("foo"), Rope::from_str("")));
+  }
+
+  #[quickcheck]
+  fn test_apply(
+    op: TextOp,
+    a: String,
+    b: char,
+    c: String,
+    d: u64,
+    e: u64,
+  ) -> TestResult {
+    let a = Rope::from(a);
+    let c = Rope::from(c);
+    let big = BigUint::from;
+    let apply1_text = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        TextOp::apply1(
+          op,
+          &Text(a.clone())
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_char_text = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        TextOp::apply2(
+          op,
+          &Char(b),
+          &Text(a.clone())
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_text_text = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        TextOp::apply2(
+          op,
+          &Text(a.clone()),
+          &Text(c.clone())
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_nat_text = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        TextOp::apply2(
+          op,
+          &Nat(big(d)),
+          &Text(a.clone())
+        ) ==
+        expected
+      )
+    };
+
+    let apply3_nat_text_text = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        TextOp::apply3(
+          op,
+          &Nat(big(d)),
+          &Text(a.clone()),
+          &Text(c.clone())
+        ) ==
+        expected
+      )
+    };
+
+    let apply3_nat_nat_text = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        TextOp::apply3(
+          op,
+          &Nat(big(d)),
+          &Nat(big(e)),
+          &Text(a.clone())
+        ) ==
+        expected
+      )
+    };
+
+    match op {
+      TextOp::Cons => {
+        let mut cs = a.clone();
+        cs.insert_char(0, b);
+        apply2_char_text(Some(Text(cs)))
+      },
+      TextOp::LenChars => apply1_text(Some(Nat(a.len_chars().into()))),
+      TextOp::LenLines => apply1_text(Some(Nat(a.len_lines().into()))),
+      TextOp::LenBytes => apply1_text(Some(Nat(a.len_bytes().into()))),
+      TextOp::Append => {
+        let mut xs = a.clone();
+        xs.append(c.clone());
+        apply2_text_text(Some(Text(xs)))
+      },
+      TextOp::Insert => apply3_nat_text_text(Some(Text(safe_insert(&big(d), a.clone(), c.clone())))),
+      TextOp::Remove => apply3_nat_nat_text(Some(Text(safe_remove(&big(d), &big(e), a.clone())))),
+      TextOp::Take => apply2_nat_text(Some(Text(safe_split(&big(d), a.clone()).0))),
+      TextOp::Drop => apply2_nat_text(Some(Text(safe_split(&big(d), a.clone()).1))),
+      TextOp::Eql => apply2_text_text(Some(Bool(a == c))),
+      TextOp::Lte => apply2_text_text(Some(Bool(a <= c))),
+      TextOp::Lth => apply2_text_text(Some(Bool(a < c))),
+      TextOp::Gte => apply2_text_text(Some(Bool(a >= c))),
+      TextOp::Gth => apply2_text_text(Some(Bool(a > c))),
+      TextOp::Char => {
+        let idx: Option<usize> = big(d).clone().try_into().ok();
+        match idx {
+          None => apply2_nat_text(None),
+          Some(idx) => if idx < a.len_chars() {
+            apply2_nat_text(Some(Char(a.char(idx))))
+          } else {
+            apply2_nat_text(None)
+          }
+        }
+      },
+      TextOp::Byte => {
+        let idx: Option<usize> = big(d).clone().try_into().ok();
+        match idx {
+          None => apply2_nat_text(None),
+          Some(idx) => if idx < a.len_chars() {
+            apply2_nat_text(Some(U8(a.byte(idx))))
+          } else {
+            apply2_nat_text(None)
+          }
+        }
+      },
+      TextOp::Line => {
+        let idx: Option<usize> = big(d).clone().try_into().ok();
+        match idx {
+          None => apply2_nat_text(None),
+          Some(idx) => if idx < a.len_lines() {
+            apply2_nat_text(Some(Text(a.line(idx).into())))
+          } else {
+            apply2_nat_text(None)
+          }
+        }
+      },
+      TextOp::CharAtByte => {
+        let idx: Option<usize> = big(d).clone().try_into().ok();
+        match idx {
+          None => apply2_nat_text(None),
+          Some(idx) => if idx < a.len_bytes() {
+            apply2_nat_text(Some(Nat(a.byte_to_char(idx).into())))
+          } else {
+            apply2_nat_text(None)
+          }
+        }
+      },
+      TextOp::ByteAtChar => {
+        let idx: Option<usize> = big(d).clone().try_into().ok();
+        match idx {
+          None => apply2_nat_text(None),
+          Some(idx) => if idx < a.len_chars() {
+            apply2_nat_text(Some(Nat(a.char_to_byte(idx).into())))
+          } else {
+            apply2_nat_text(None)
+          }
+        }
+      },
+      TextOp::LineAtByte => {
+        let idx: Option<usize> = big(d).clone().try_into().ok();
+        match idx {
+          None => apply2_nat_text(None),
+          Some(idx) => if idx < a.len_bytes() {
+            apply2_nat_text(Some(Nat(a.byte_to_line(idx).into())))
+          } else {
+            apply2_nat_text(None)
+          }
+        }
+      },
+      TextOp::LineAtChar => {
+        let idx: Option<usize> = big(d).clone().try_into().ok();
+        match idx {
+          None => apply2_nat_text(None),
+          Some(idx) => if idx < a.len_chars() {
+            apply2_nat_text(Some(Nat(a.char_to_line(idx).into())))
+          } else {
+            apply2_nat_text(None)
+          }
+        }
+      },
+      TextOp::LineStartChar => {
+        let idx: Option<usize> = big(d).clone().try_into().ok();
+        match idx {
+          None => apply2_nat_text(None),
+          Some(idx) => if idx < a.len_lines() {
+            apply2_nat_text(Some(Nat(a.line_to_char(idx).into())))
+          } else {
+            apply2_nat_text(None)
+          }
+        }
+      },
+      TextOp::LineStartByte => {
+        let idx: Option<usize> = big(d).clone().try_into().ok();
+        match idx {
+          None => apply2_nat_text(None),
+          Some(idx) => if idx < a.len_lines() {
+            apply2_nat_text(Some(Nat(a.line_to_byte(idx).into())))
+          } else {
+            apply2_nat_text(None)
+          }
+        }
+      },
+      TextOp::ToBytes => apply1_text(Some(Bytes(a.bytes().collect::<Vec<u8>>()))),
+    }
+  }
+
+  #[derive(Debug, Clone)]
+  struct ArgsApplyNoneOnInvalid(TextOp, Literal, String, char, String, u64, u64, bool, TestArg3);
+
+  impl Arbitrary for ArgsApplyNoneOnInvalid {
+    fn arbitrary(g: &mut Gen) -> ArgsApplyNoneOnInvalid {
+      ArgsApplyNoneOnInvalid(
+        TextOp::arbitrary(g),
+        Literal::arbitrary(g),
+        String::arbitrary(g),
+        char::arbitrary(g),
+        String::arbitrary(g),
+        u64::arbitrary(g),
+        u64::arbitrary(g),
+        bool::arbitrary(g),
+        TestArg3::arbitrary(g)
+      )
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply_none_on_invalid(args: ArgsApplyNoneOnInvalid) -> TestResult {
+    let op = args.0;
+    let a = args.1;
+    let b = Rope::from(args.2);
+    let c = args.3;
+    let d = Rope::from(args.4);
+    let e = args.5;
+    let f = args.6;
+    let test_arg_2 = args.7;
+    let test_arg_3 = args.8;
+    let big = BigUint::from;
+    let test_apply1_none_on_invalid = |
+      valid_arg: Literal
+    | -> TestResult {
+      if mem::discriminant(&valid_arg) == mem::discriminant(&a) {
+        TestResult::discard()
+      } else {
+        TestResult::from_bool(
+          TextOp::apply1(
+            op,
+            &a
+          ) ==
+          None
+        )
+      }
+    };
+
+    let test_apply2_none_on_invalid = |
+      valid_arg: Literal,
+      a_: Literal,
+      b_: Literal
+    | -> TestResult {
+      let go = || TestResult::from_bool(
+        TextOp::apply2(
+          op,
+          &a_,
+          &b_
+        ) ==
+        None
+      );
+      if test_arg_2 {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&a_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      } else {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&b_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      }
+    };
+
+    let test_apply3_none_on_invalid = |
+      valid_arg: Literal,
+      a_: Literal,
+      b_: Literal,
+      c_: Literal
+    | -> TestResult {
+      let go = || TestResult::from_bool(
+        TextOp::apply3(
+          op,
+          &a_,
+          &b_,
+          &c_
+        ) ==
+        None
+      );
+      match test_arg_3 {
+        TestArg3::A => if mem::discriminant(&valid_arg) == mem::discriminant(&a_) {
+          TestResult::discard()
+        } else {
+          go()
+        },
+        TestArg3::B => if mem::discriminant(&valid_arg) == mem::discriminant(&b_) {
+          TestResult::discard()
+        } else {
+          go()
+        },
+        TestArg3::C => if mem::discriminant(&valid_arg) == mem::discriminant(&c_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      }
+    };
+
+    match op {
+      // Arity 1, valid is Text.
+      TextOp::LenChars |
+      TextOp::LenBytes |
+      TextOp::LenLines |
+      TextOp::ToBytes => test_apply1_none_on_invalid(Text(b)),
+      // Arity 2, valid are Char on a and Text on b.
+      TextOp::Cons => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          Char(c),
+          a,
+          Text(b.clone())
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          Text(b.clone()),
+          Char(c),
+          a
+        )
+      },
+      // Arity 2, valid are Text on a and b.
+      TextOp::Append |
+      TextOp::Eql |
+      TextOp::Lte |
+      TextOp::Lth |
+      TextOp::Gte |
+      TextOp::Gth => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          Text(b.clone()),
+          a,
+          Text(b.clone())
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          Text(b.clone()),
+          Text(b.clone()),
+          a
+        )
+      },
+      // Arity 2, valid are Nat on a and Text on b.
+      TextOp::Take |
+      TextOp::Drop |
+      TextOp::Char |
+      TextOp::Byte |
+      TextOp::Line |
+      TextOp::CharAtByte |
+      TextOp::ByteAtChar |
+      TextOp::LineAtChar |
+      TextOp::LineAtByte |
+      TextOp::LineStartChar |
+      TextOp::LineStartByte => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          Nat(big(e)),
+          a,
+          Text(b.clone())
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          Text(b.clone()),
+          Nat(big(e)),
+          a
+        )
+      },
+      // Arity 3, valid are Nat on a, Text on b and Text on c.
+      TextOp::Insert => match test_arg_3 {
+        TestArg3::A => test_apply3_none_on_invalid(
+          Nat(big(e)),
+          a,
+          Text(b.clone()),
+          Text(d.clone())
+        ),
+        TestArg3::B => test_apply3_none_on_invalid(
+          Text(b.clone()),
+          Nat(big(e)),
+          a,
+          Text(b.clone())
+        ),
+        TestArg3::C => test_apply3_none_on_invalid(
+          Text(b.clone()),
+          Nat(big(e)),
+          Text(b.clone()),
+          a
+        ),
+      },
+      // Arity 3, valid are Nat on a, Nat on b and Text on c.
+      TextOp::Remove => match test_arg_3 {
+        TestArg3::A => test_apply3_none_on_invalid(
+          Nat(big(e)),
+          a,
+          Nat(big(e)),
+          Text(d.clone())
+        ),
+        TestArg3::B => test_apply3_none_on_invalid(
+          Nat(big(e)),
+          Nat(big(e)),
+          a,
+          Text(b.clone())
+        ),
+        TestArg3::C => test_apply3_none_on_invalid(
+          Text(b.clone()),
+          Nat(big(e)),
+          Nat(big(f)),
+          a
+        ),
+      },
+    }
   }
 }

--- a/core/src/prim/u16.rs
+++ b/core/src/prim/u16.rs
@@ -13,6 +13,8 @@ use crate::{
   yatima,
 };
 
+use num_bigint::BigUint;
+
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum U16Op {
   Max,
@@ -90,8 +92,8 @@ impl U16Op {
       Self::ToI64 => "to_I64".to_owned(),
       Self::ToI128 => "to_I128".to_owned(),
       Self::ToInt => "to_Int".to_owned(),
-      Self::ToBytes => "to_Bytes".to_owned(),
       Self::ToBits => "to_Bits".to_owned(),
+      Self::ToBytes => "to_Bytes".to_owned(),
     }
   }
 
@@ -131,8 +133,8 @@ impl U16Op {
       "to_I64" => Some(Self::ToI64),
       "to_I128" => Some(Self::ToI128),
       "to_Int" => Some(Self::ToInt),
-      "to_Bytes" => Some(Self::ToBytes),
       "to_Bits" => Some(Self::ToBits),
+      "to_Bytes" => Some(Self::ToBytes),
       _ => None,
     }
   }
@@ -173,8 +175,8 @@ impl U16Op {
       Self::ToI64 => yatima!("∀ #U16 -> #I64"),
       Self::ToI128 => yatima!("∀ #U16 -> #I128"),
       Self::ToInt => yatima!("∀ #U16 -> #Int"),
-      Self::ToBytes => yatima!("∀ #U16 -> #Bytes"),
       Self::ToBits => yatima!("∀ #U8 -> #Bits"),
+      Self::ToBytes => yatima!("∀ #U16 -> #Bytes"),
     }
   }
 
@@ -297,8 +299,8 @@ impl U16Op {
       Self::ToI64 => 1,
       Self::ToI128 => 1,
       Self::ToInt => 1,
-      Self::ToBytes => 1,
       Self::ToBits => 1,
+      Self::ToBytes => 1,
     }
   }
 
@@ -316,10 +318,11 @@ impl U16Op {
     match (self, x) {
       (Self::CountZeros, U16(x)) => Some(U32(x.count_zeros())),
       (Self::CountOnes, U16(x)) => Some(U32(x.count_ones())),
-      (Self::ToU8, U16(x)) => u16::try_from(*x).ok().map(U16),
+      (Self::ToU8, U16(x)) => u8::try_from(*x).ok().map(U8),
       (Self::ToU32, U16(x)) => Some(U32((*x).into())),
       (Self::ToU64, U16(x)) => Some(U64((*x).into())),
       (Self::ToU128, U16(x)) => Some(U128((*x).into())),
+      (Self::ToNat, U16(x)) => Some(Nat(BigUint::from(u64::try_from(*x).unwrap()))),
       (Self::ToI8, U16(x)) => i8::try_from(*x).ok().map(I8),
       (Self::ToI16, U16(x)) => i16::try_from(*x).ok().map(I16),
       (Self::ToI32, U16(x)) => Some(I32((*x).into())),
@@ -327,10 +330,8 @@ impl U16Op {
       (Self::ToI128, U16(x)) => Some(I128((*x).into())),
       (Self::Not, U16(x)) => Some(U16(!x)),
       (Self::ToInt, U16(x)) => Some(Int((*x).into())),
+      (Self::ToBits, U16(x)) => Some(Bits(bits::bytes_to_bits(16, &x.to_be_bytes().into()))),
       (Self::ToBytes, U16(x)) => Some(Bytes(x.to_be_bytes().into())),
-      (Self::ToBits, U16(x)) => {
-        Some(Bits(bits::bytes_to_bits(16, &x.to_be_bytes().into())))
-      }
       _ => None,
     }
   }
@@ -349,8 +350,16 @@ impl U16Op {
       (Self::Add, U16(x), U16(y)) => Some(U16(x.wrapping_add(*y))),
       (Self::Sub, U16(x), U16(y)) => Some(U16(x.wrapping_sub(*y))),
       (Self::Mul, U16(x), U16(y)) => Some(U16(x.wrapping_mul(*y))),
-      (Self::Div, U16(x), U16(y)) => Some(U16(x.wrapping_div(*y))),
-      (Self::Mod, U16(x), U16(y)) => Some(U16(x.wrapping_rem(*y))),
+      (Self::Div, U16(x), U16(y)) => if *y == 0 {
+        None
+      } else {
+        Some(U16(x.wrapping_div(*y)))
+      },
+      (Self::Mod, U16(x), U16(y)) => if *y == 0 {
+        None
+      } else {
+        Some(U16(x.wrapping_rem(*y)))
+      },
       (Self::Pow, U16(x), U32(y)) => Some(U16(x.wrapping_pow(*y))),
       (Self::Shl, U32(x), U16(y)) => Some(U16(y.wrapping_shl(*x))),
       (Self::Shr, U32(x), U16(y)) => Some(U16(y.wrapping_shr(*x))),
@@ -373,12 +382,36 @@ pub mod tests {
   use quickcheck::{
     Arbitrary,
     Gen,
+    TestResult
   };
   use rand::Rng;
+  use Literal::{
+    U16,
+    Bool,
+    Nat,
+    Int,
+    Bits,
+    Bytes,
+    U32
+  };
+  use crate::prim::{
+    U8Op,
+    U32Op,
+    U64Op,
+    I8Op,
+    I16Op,
+    I32Op,
+    I64Op,
+  };
+  use std::{
+    convert::TryInto,
+    mem
+  };
+  use num_bigint::BigUint;
   impl Arbitrary for U16Op {
     fn arbitrary(_g: &mut Gen) -> Self {
       let mut rng = rand::thread_rng();
-      let gen: u32 = rng.gen_range(0..34);
+      let gen: u32 = rng.gen_range(0..=33);
       match gen {
         0 => Self::Max,
         1 => Self::Min,
@@ -406,15 +439,16 @@ pub mod tests {
         23 => Self::ToU8,
         24 => Self::ToU32,
         25 => Self::ToU64,
-        26 => Self::ToU128,
-        27 => Self::ToNat,
-        28 => Self::ToI8,
-        29 => Self::ToI16,
-        30 => Self::ToI32,
-        31 => Self::ToI64,
-        32 => Self::ToI128,
-        33 => Self::ToInt,
-        _ => Self::ToBytes,
+        26 => Self::ToNat,
+        27 => Self::ToI8,
+        28 => Self::ToI16,
+        29 => Self::ToI32,
+        30 => Self::ToI64,
+        31 => Self::ToInt,
+        32 => Self::ToBytes,
+        _ => Self::ToBits,
+        // 26 => Self::ToU128,
+        // 32 => Self::ToI128,
       }
     }
   }
@@ -424,6 +458,297 @@ pub mod tests {
     match U16Op::from_ipld(&x.to_ipld()) {
       Ok(y) => x == y,
       _ => false,
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply(
+    op: U16Op,
+    a: u16,
+    b: u16,
+    c: u32
+  ) -> TestResult {
+    let apply0_go = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        U16Op::apply0(op) ==
+        expected
+      )
+    };
+
+    let apply1_u16 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        U16Op::apply1(
+          op,
+          &U16(a)
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_u16_u16 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        U16Op::apply2(
+          op,
+          &U16(a),
+          &U16(b)
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_u16_u32 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        U16Op::apply2(
+          op,
+          &U16(a),
+          &U32(c)
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_u32_u16 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        U16Op::apply2(
+          op,
+          &U32(c),
+          &U16(a)
+        ) ==
+        expected
+      )
+    };
+
+    let from_bool = TestResult::from_bool;
+
+    match op {
+      U16Op::Max => apply0_go(Some(U16(u16::MAX))),
+      U16Op::Min => apply0_go(Some(U16(u16::MIN))),
+      U16Op::Eql => apply2_u16_u16(Some(Bool(a == b))),
+      U16Op::Lte => apply2_u16_u16(Some(Bool(a <= b))),
+      U16Op::Lth => apply2_u16_u16(Some(Bool(a < b))),
+      U16Op::Gth => apply2_u16_u16(Some(Bool(a > b))),
+      U16Op::Gte => apply2_u16_u16(Some(Bool(a >= b))),
+      U16Op::Not => apply1_u16(Some(U16(!a))),
+      U16Op::And => apply2_u16_u16(Some(U16(a & b))),
+      U16Op::Or => apply2_u16_u16(Some(U16(a | b))),
+      U16Op::Xor => apply2_u16_u16(Some(U16(a ^ b))),
+      U16Op::Add => apply2_u16_u16(Some(U16(a.wrapping_add(b)))),
+      U16Op::Sub => apply2_u16_u16(Some(U16(a.wrapping_sub(b)))),
+      U16Op::Mul => apply2_u16_u16(Some(U16(a.wrapping_mul(b)))),
+      U16Op::Div => apply2_u16_u16(
+        if b == 0 {
+          None
+        } else {
+          Some(U16(a.wrapping_div(b)))
+        }
+      ),
+      U16Op::Mod => apply2_u16_u16(
+        if b == 0 {
+          None
+        } else {
+          Some(U16(a.wrapping_rem(b)))
+        }
+      ),
+      U16Op::Pow => apply2_u16_u32(Some(U16(a.wrapping_pow(c)))),
+      U16Op::Shl => apply2_u32_u16(Some(U16(a.wrapping_shl(c)))),
+      U16Op::Shr => apply2_u32_u16(Some(U16(a.wrapping_shr(c)))),
+      U16Op::Rol => apply2_u32_u16(Some(U16(a.rotate_left(c)))),
+      U16Op::Ror => apply2_u32_u16(Some(U16(a.rotate_right(c)))),
+      U16Op::CountZeros => apply1_u16(Some(U32(a.count_zeros()))),
+      U16Op::CountOnes => apply1_u16(Some(U32(a.count_ones()))),
+      U16Op::ToU8 => from_bool(
+        if a > u8::MAX.into() {
+          U16Op::apply1(op, &U16(a)) == None
+        } else {
+          U8Op::apply1(
+            U8Op::ToU16,
+            &U16Op::apply1(op, &U16(a)).unwrap()
+          ) == Some(U16(a))
+        }
+      ),
+      U16Op::ToU32 => from_bool(
+        U32Op::apply1(
+          U32Op::ToU16,
+          &U16Op::apply1(op, &U16(a)).unwrap()
+        ) == Some(U16(a))
+      ),
+      U16Op::ToU64 => from_bool(
+        U64Op::apply1(
+          U64Op::ToU16,
+          &U16Op::apply1(op, &U16(a)).unwrap()
+        ) == Some(U16(a))
+      ),
+      U16Op::ToU128 => TestResult::discard(),
+      U16Op::ToNat => apply1_u16(Some(Nat(BigUint::from(u64::try_from(a).unwrap())))),
+      U16Op::ToI8 => from_bool(
+        if a > i8::MAX.try_into().unwrap() {
+          U16Op::apply1(op, &U16(a)) == None
+        } else {
+          I8Op::apply1(
+            I8Op::ToU16,
+            &U16Op::apply1(op, &U16(a)).unwrap()
+          ) == Some(U16(a))
+        }
+      ),
+      U16Op::ToI16 => from_bool(
+        if a > i16::MAX.try_into().unwrap() {
+          U16Op::apply1(op, &U16(a)) == None
+        } else {
+          I16Op::apply1(
+            I16Op::ToU16,
+            &U16Op::apply1(op, &U16(a)).unwrap()
+          ) == Some(U16(a))
+        }
+      ),
+      U16Op::ToI32 => from_bool(
+        I32Op::apply1(
+          I32Op::ToU16,
+          &U16Op::apply1(op, &U16(a)).unwrap()
+        ) == Some(U16(a))
+      ),
+      U16Op::ToI64 => from_bool(
+        I64Op::apply1(
+          I64Op::ToU16,
+          &U16Op::apply1(op, &U16(a)).unwrap()
+        ) == Some(U16(a))
+      ),
+      U16Op::ToI128 => TestResult::discard(),
+      U16Op::ToInt => apply1_u16(Some(Int(a.into()))),
+      U16Op::ToBits => apply1_u16(Some(Bits(bits::bytes_to_bits(16, &a.to_be_bytes().into())))),
+      U16Op::ToBytes => apply1_u16(Some(Bytes(a.to_be_bytes().into()))),
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply_none_on_invalid(
+    op: U16Op,
+    a: Literal,
+    b: u16,
+    c: u32,
+    test_arg_2: bool,
+  ) -> TestResult {
+    let test_apply1_none_on_invalid = |
+      valid_arg: Literal
+    | -> TestResult {
+      if mem::discriminant(&valid_arg) == mem::discriminant(&a) {
+        TestResult::discard()
+      } else {
+        TestResult::from_bool(
+          U16Op::apply1(
+            op,
+            &a
+          ) ==
+          None
+        )
+      }
+    };
+
+    let test_apply2_none_on_invalid = |
+      valid_arg: Literal,
+      a_: Literal,
+      b_: Literal
+    | -> TestResult {
+      let go = || TestResult::from_bool(
+        U16Op::apply2(
+          op,
+          &a_,
+          &b_
+        ) ==
+        None
+      );
+      if test_arg_2 {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&a_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      } else {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&b_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      }
+    };
+
+    match op {
+      // Arity 0.
+      U16Op::Max |
+      U16Op::Min => TestResult::discard(),
+      // Arity 1, valid is U16.
+      U16Op::Not |
+      U16Op::CountZeros |
+      U16Op::CountOnes |
+      U16Op::ToU8 |
+      U16Op::ToU32 |
+      U16Op::ToU64 |
+      U16Op::ToU128 |
+      U16Op::ToNat |
+      U16Op::ToI8 |
+      U16Op::ToI16 |
+      U16Op::ToI32 |
+      U16Op::ToI64 |
+      U16Op::ToI128 |
+      U16Op::ToInt |
+      U16Op::ToBytes |
+      U16Op::ToBits => test_apply1_none_on_invalid(U16(b)),
+      // Arity 2, valid are U16 on a and b.
+      U16Op::Eql |
+      U16Op::Lte |
+      U16Op::Lth |
+      U16Op::Gth |
+      U16Op::Gte |
+      U16Op::And |
+      U16Op::Or |
+      U16Op::Xor |
+      U16Op::Add |
+      U16Op::Sub |
+      U16Op::Mul |
+      U16Op::Div |
+      U16Op::Mod => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          U16(b),
+          a,
+          U16(b)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          U16(b),
+          U16(b),
+          a
+        )
+      },
+      // Arity 2, valid are U16 on a and U32 on b.
+      U16Op::Pow => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          U16(b),
+          a,
+          U32(c)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          U32(c),
+          U16(b),
+          a
+        )
+      },
+      // Arity 2, valid are U32 on a and U16 on b.
+      U16Op::Shl |
+      U16Op::Shr |
+      U16Op::Rol |
+      U16Op::Ror => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          U32(c),
+          a,
+          U16(b)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          U16(b),
+          U32(c),
+          a
+        )
+      }
     }
   }
 }

--- a/core/src/prim/u32.rs
+++ b/core/src/prim/u32.rs
@@ -13,6 +13,8 @@ use crate::{
   yatima,
 };
 
+use num_bigint::BigUint;
+
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum U32Op {
   Max,
@@ -323,11 +325,11 @@ impl U32Op {
     match (self, x) {
       (Self::CountZeros, U32(x)) => Some(U32(x.count_zeros())),
       (Self::CountOnes, U32(x)) => Some(U32(x.count_ones())),
-      (Self::ToChar, U32(x)) => char::from_u32(*x).map(Char),
       (Self::ToU8, U32(x)) => u8::try_from(*x).ok().map(U8),
       (Self::ToU16, U32(x)) => u16::try_from(*x).ok().map(U16),
       (Self::ToU64, U32(x)) => Some(U64((*x).into())),
       (Self::ToU128, U32(x)) => Some(U128((*x).into())),
+      (Self::ToNat, U32(x)) => Some(Nat(BigUint::from(u64::try_from(*x).unwrap()))),
       (Self::ToI8, U32(x)) => i8::try_from(*x).ok().map(I8),
       (Self::ToI16, U32(x)) => i16::try_from(*x).ok().map(I16),
       (Self::ToI32, U32(x)) => i32::try_from(*x).ok().map(I32),
@@ -335,10 +337,9 @@ impl U32Op {
       (Self::ToI128, U32(x)) => Some(I128((*x).into())),
       (Self::Not, U32(x)) => Some(U32(!x)),
       (Self::ToInt, U32(x)) => Some(Int((*x).into())),
+      (Self::ToBits, U32(x)) => Some(Bits(bits::bytes_to_bits(32, &x.to_be_bytes().into()))),
       (Self::ToBytes, U32(x)) => Some(Bytes(x.to_be_bytes().into())),
-      (Self::ToBits, U32(x)) => {
-        Some(Bits(bits::bytes_to_bits(32, &x.to_be_bytes().into())))
-      }
+      (Self::ToChar, U32(x)) => char::from_u32(*x).map(Char),
       _ => None,
     }
   }
@@ -357,8 +358,16 @@ impl U32Op {
       (Self::Add, U32(x), U32(y)) => Some(U32(x.wrapping_add(*y))),
       (Self::Sub, U32(x), U32(y)) => Some(U32(x.wrapping_sub(*y))),
       (Self::Mul, U32(x), U32(y)) => Some(U32(x.wrapping_mul(*y))),
-      (Self::Div, U32(x), U32(y)) => Some(U32(x.wrapping_div(*y))),
-      (Self::Mod, U32(x), U32(y)) => Some(U32(x.wrapping_rem(*y))),
+      (Self::Div, U32(x), U32(y)) => if *y == 0 {
+        None
+      } else {
+        Some(U32(x.wrapping_div(*y)))
+      },
+      (Self::Mod, U32(x), U32(y)) => if *y == 0 {
+        None
+      } else {
+        Some(U32(x.wrapping_rem(*y)))
+      },
       (Self::Pow, U32(x), U32(y)) => Some(U32(x.wrapping_pow(*y))),
       (Self::Shl, U32(x), U32(y)) => Some(U32(y.wrapping_shl(*x))),
       (Self::Shr, U32(x), U32(y)) => Some(U32(y.wrapping_shr(*x))),
@@ -381,12 +390,36 @@ pub mod tests {
   use quickcheck::{
     Arbitrary,
     Gen,
+    TestResult
   };
   use rand::Rng;
+  use Literal::{
+    U32,
+    Bool,
+    Nat,
+    Int,
+    Bits,
+    Bytes,
+    Char
+  };
+  use crate::prim::{
+    U8Op,
+    U16Op,
+    U64Op,
+    I8Op,
+    I16Op,
+    I32Op,
+    I64Op,
+  };
+  use std::{
+    convert::TryInto,
+    mem
+  };
+  use num_bigint::BigUint;
   impl Arbitrary for U32Op {
     fn arbitrary(_g: &mut Gen) -> Self {
       let mut rng = rand::thread_rng();
-      let gen: u32 = rng.gen_range(0..11);
+      let gen: u32 = rng.gen_range(0..=34);
       match gen {
         0 => Self::Max,
         1 => Self::Min,
@@ -415,15 +448,16 @@ pub mod tests {
         24 => Self::ToU8,
         25 => Self::ToU16,
         26 => Self::ToU64,
-        27 => Self::ToU128,
-        28 => Self::ToNat,
-        29 => Self::ToI8,
-        30 => Self::ToI16,
-        31 => Self::ToI32,
-        32 => Self::ToI64,
-        33 => Self::ToI128,
-        34 => Self::ToInt,
-        _ => Self::ToBytes,
+        27 => Self::ToNat,
+        28 => Self::ToI8,
+        29 => Self::ToI16,
+        30 => Self::ToI32,
+        31 => Self::ToI64,
+        32 => Self::ToInt,
+        33 => Self::ToBytes,
+        _ => Self::ToBits,
+        // 27 => Self::ToU128,
+        // 33 => Self::ToI128,
       }
     }
   }
@@ -433,6 +467,307 @@ pub mod tests {
     match U32Op::from_ipld(&x.to_ipld()) {
       Ok(y) => x == y,
       _ => false,
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply(
+    op: U32Op,
+    a: u32,
+    b: u32,
+    c: u32
+  ) -> TestResult {
+    let apply0_go = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        U32Op::apply0(op) ==
+        expected
+      )
+    };
+
+    let apply1_u32 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        U32Op::apply1(
+          op,
+          &U32(a)
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_u32_a_u32_b = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        U32Op::apply2(
+          op,
+          &U32(a),
+          &U32(b)
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_u32_a_u32_c = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        U32Op::apply2(
+          op,
+          &U32(a),
+          &U32(c)
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_u32_c_u32_a = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        U32Op::apply2(
+          op,
+          &U32(c),
+          &U32(a)
+        ) ==
+        expected
+      )
+    };
+
+    let from_bool = TestResult::from_bool;
+
+    match op {
+      U32Op::Max => apply0_go(Some(U32(u32::MAX))),
+      U32Op::Min => apply0_go(Some(U32(u32::MIN))),
+      U32Op::Eql => apply2_u32_a_u32_b(Some(Bool(a == b))),
+      U32Op::Lte => apply2_u32_a_u32_b(Some(Bool(a <= b))),
+      U32Op::Lth => apply2_u32_a_u32_b(Some(Bool(a < b))),
+      U32Op::Gth => apply2_u32_a_u32_b(Some(Bool(a > b))),
+      U32Op::Gte => apply2_u32_a_u32_b(Some(Bool(a >= b))),
+      U32Op::Not => apply1_u32(Some(U32(!a))),
+      U32Op::And => apply2_u32_a_u32_b(Some(U32(a & b))),
+      U32Op::Or => apply2_u32_a_u32_b(Some(U32(a | b))),
+      U32Op::Xor => apply2_u32_a_u32_b(Some(U32(a ^ b))),
+      U32Op::Add => apply2_u32_a_u32_b(Some(U32(a.wrapping_add(b)))),
+      U32Op::Sub => apply2_u32_a_u32_b(Some(U32(a.wrapping_sub(b)))),
+      U32Op::Mul => apply2_u32_a_u32_b(Some(U32(a.wrapping_mul(b)))),
+      U32Op::Div => apply2_u32_a_u32_b(
+        if b == 0 {
+          None
+        } else {
+          Some(U32(a.wrapping_div(b)))
+        }
+      ),
+      U32Op::Mod => apply2_u32_a_u32_b(
+        if b == 0 {
+          None
+        } else {
+          Some(U32(a.wrapping_rem(b)))
+        }
+      ),
+      U32Op::Pow => apply2_u32_a_u32_c(Some(U32(a.wrapping_pow(c)))),
+      U32Op::Shl => apply2_u32_c_u32_a(Some(U32(a.wrapping_shl(c)))),
+      U32Op::Shr => apply2_u32_c_u32_a(Some(U32(a.wrapping_shr(c)))),
+      U32Op::Rol => apply2_u32_c_u32_a(Some(U32(a.rotate_left(c)))),
+      U32Op::Ror => apply2_u32_c_u32_a(Some(U32(a.rotate_right(c)))),
+      U32Op::CountZeros => apply1_u32(Some(U32(a.count_zeros()))),
+      U32Op::CountOnes => apply1_u32(Some(U32(a.count_ones()))),
+      U32Op::ToU8 => from_bool(
+        if a > u8::MAX.into() {
+          U32Op::apply1(op, &U32(a)) == None
+        } else {
+          U8Op::apply1(
+            U8Op::ToU32,
+            &U32Op::apply1(op, &U32(a)).unwrap()
+          ) == Some(U32(a))
+        }
+      ),
+      U32Op::ToU16 => from_bool(
+        if a > u16::MAX.into() {
+          U32Op::apply1(op, &U32(a)) == None
+        } else {
+          U16Op::apply1(
+            U16Op::ToU32,
+            &U32Op::apply1(op, &U32(a)).unwrap()
+          ) == Some(U32(a))
+        }
+      ),
+      U32Op::ToU64 => from_bool(
+        U64Op::apply1(
+          U64Op::ToU32,
+          &U32Op::apply1(op, &U32(a)).unwrap()
+        ) == Some(U32(a))
+      ),
+      U32Op::ToU128 => TestResult::discard(),
+      U32Op::ToNat => apply1_u32(Some(Nat(BigUint::from(u64::try_from(a).unwrap())))),
+      U32Op::ToI8 => from_bool(
+        if a > i8::MAX.try_into().unwrap() {
+          U32Op::apply1(op, &U32(a)) == None
+        } else {
+          I8Op::apply1(
+            I8Op::ToU32,
+            &U32Op::apply1(op, &U32(a)).unwrap()
+          ) == Some(U32(a))
+        }
+      ),
+      U32Op::ToI16 => from_bool(
+        if a > i16::MAX.try_into().unwrap() {
+          U32Op::apply1(op, &U32(a)) == None
+        } else {
+          I16Op::apply1(
+            I16Op::ToU32,
+            &U32Op::apply1(op, &U32(a)).unwrap()
+          ) == Some(U32(a))
+        }
+      ),
+      U32Op::ToI32 => from_bool(
+        if a > i32::MAX.try_into().unwrap() {
+          U32Op::apply1(op, &U32(a)) == None
+        } else {
+          I32Op::apply1(
+            I32Op::ToU32,
+            &U32Op::apply1(op, &U32(a)).unwrap()
+          ) == Some(U32(a))
+        }
+      ),
+      U32Op::ToI64 => from_bool(
+        I64Op::apply1(
+          I64Op::ToU32,
+          &U32Op::apply1(op, &U32(a)).unwrap()
+        ) == Some(U32(a))
+      ),
+      U32Op::ToI128 => TestResult::discard(),
+      U32Op::ToInt => apply1_u32(Some(Int(a.into()))),
+      U32Op::ToBits => apply1_u32(Some(Bits(bits::bytes_to_bits(32, &a.to_be_bytes().into())))),
+      U32Op::ToBytes => apply1_u32(Some(Bytes(a.to_be_bytes().into()))),
+      U32Op::ToChar => apply1_u32(char::from_u32(a).map(Char)),
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply_none_on_invalid(
+    op: U32Op,
+    a: Literal,
+    b: u32,
+    c: u32,
+    test_arg_2: bool,
+  ) -> TestResult {
+    let test_apply1_none_on_invalid = |
+      valid_arg: Literal
+    | -> TestResult {
+      if mem::discriminant(&valid_arg) == mem::discriminant(&a) {
+        TestResult::discard()
+      } else {
+        TestResult::from_bool(
+          U32Op::apply1(
+            op,
+            &a
+          ) ==
+          None
+        )
+      }
+    };
+
+    let test_apply2_none_on_invalid = |
+      valid_arg: Literal,
+      a_: Literal,
+      b_: Literal
+    | -> TestResult {
+      let go = || TestResult::from_bool(
+        U32Op::apply2(
+          op,
+          &a_,
+          &b_
+        ) ==
+        None
+      );
+      if test_arg_2 {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&a_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      } else {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&b_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      }
+    };
+
+    match op {
+      // Arity 0.
+      U32Op::Max |
+      U32Op::Min => TestResult::discard(),
+      // Arity 1, valid is U32.
+      U32Op::Not |
+      U32Op::CountZeros |
+      U32Op::CountOnes |
+      U32Op::ToU8 |
+      U32Op::ToU16 |
+      U32Op::ToU64 |
+      U32Op::ToU128 |
+      U32Op::ToNat |
+      U32Op::ToI8 |
+      U32Op::ToI16 |
+      U32Op::ToI32 |
+      U32Op::ToI64 |
+      U32Op::ToI128 |
+      U32Op::ToInt |
+      U32Op::ToBytes |
+      U32Op::ToBits |
+      U32Op::ToChar => test_apply1_none_on_invalid(U32(b)),
+      // Arity 2, valid are U32 on a and b.
+      U32Op::Eql |
+      U32Op::Lte |
+      U32Op::Lth |
+      U32Op::Gth |
+      U32Op::Gte |
+      U32Op::And |
+      U32Op::Or |
+      U32Op::Xor |
+      U32Op::Add |
+      U32Op::Sub |
+      U32Op::Mul |
+      U32Op::Div |
+      U32Op::Mod => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          U32(b),
+          a,
+          U32(b)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          U32(b),
+          U32(b),
+          a
+        )
+      },
+      // Arity 2, valid are U32 on a and U32 on b.
+      U32Op::Pow => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          U32(b),
+          a,
+          U32(c)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          U32(c),
+          U32(b),
+          a
+        )
+      },
+      // Arity 2, valid are U32 on a and U32 on b.
+      U32Op::Shl |
+      U32Op::Shr |
+      U32Op::Rol |
+      U32Op::Ror => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          U32(c),
+          a,
+          U32(b)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          U32(b),
+          U32(c),
+          a
+        )
+      }
     }
   }
 }

--- a/core/src/prim/u64.rs
+++ b/core/src/prim/u64.rs
@@ -13,6 +13,8 @@ use crate::{
   yatima,
 };
 
+use num_bigint::BigUint;
+
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum U64Op {
   Max,
@@ -49,8 +51,8 @@ pub enum U64Op {
   ToI64,
   ToI128,
   ToInt,
-  ToBytes,
   ToBits,
+  ToBytes,
 }
 
 impl U64Op {
@@ -297,8 +299,8 @@ impl U64Op {
       Self::ToI64 => 1,
       Self::ToI128 => 1,
       Self::ToInt => 1,
-      Self::ToBytes => 1,
       Self::ToBits => 1,
+      Self::ToBytes => 1,
     }
   }
 
@@ -320,6 +322,7 @@ impl U64Op {
       (Self::ToU16, U64(x)) => u16::try_from(*x).ok().map(U16),
       (Self::ToU32, U64(x)) => u32::try_from(*x).ok().map(U32),
       (Self::ToU128, U64(x)) => Some(U128((*x).into())),
+      (Self::ToNat, U64(x)) => Some(Nat(BigUint::from(*x))),
       (Self::ToI8, U64(x)) => i8::try_from(*x).ok().map(I8),
       (Self::ToI16, U64(x)) => i16::try_from(*x).ok().map(I16),
       (Self::ToI32, U64(x)) => i32::try_from(*x).ok().map(I32),
@@ -327,10 +330,8 @@ impl U64Op {
       (Self::ToI128, U64(x)) => Some(I128((*x).into())),
       (Self::Not, U64(x)) => Some(U64(!x)),
       (Self::ToInt, U64(x)) => Some(Int((*x).into())),
+      (Self::ToBits, U64(x)) => Some(Bits(bits::bytes_to_bits(64, &x.to_be_bytes().into()))),
       (Self::ToBytes, U64(x)) => Some(Bytes(x.to_be_bytes().into())),
-      (Self::ToBits, U64(x)) => {
-        Some(Bits(bits::bytes_to_bits(64, &x.to_be_bytes().into())))
-      }
       _ => None,
     }
   }
@@ -349,8 +350,16 @@ impl U64Op {
       (Self::Add, U64(x), U64(y)) => Some(U64(x.wrapping_add(*y))),
       (Self::Sub, U64(x), U64(y)) => Some(U64(x.wrapping_sub(*y))),
       (Self::Mul, U64(x), U64(y)) => Some(U64(x.wrapping_mul(*y))),
-      (Self::Div, U64(x), U64(y)) => Some(U64(x.wrapping_div(*y))),
-      (Self::Mod, U64(x), U64(y)) => Some(U64(x.wrapping_rem(*y))),
+      (Self::Div, U64(x), U64(y)) => if *y == 0 {
+        None
+      } else {
+        Some(U64(x.wrapping_div(*y)))
+      },
+      (Self::Mod, U64(x), U64(y)) => if *y == 0 {
+        None
+      } else {
+        Some(U64(x.wrapping_rem(*y)))
+      },
       (Self::Pow, U64(x), U32(y)) => Some(U64(x.wrapping_pow(*y))),
       (Self::Shl, U32(x), U64(y)) => Some(U64(y.wrapping_shl(*x))),
       (Self::Shr, U32(x), U64(y)) => Some(U64(y.wrapping_shr(*x))),
@@ -373,12 +382,36 @@ pub mod tests {
   use quickcheck::{
     Arbitrary,
     Gen,
+    TestResult
   };
   use rand::Rng;
+  use Literal::{
+    U64,
+    Bool,
+    Nat,
+    Int,
+    Bits,
+    Bytes,
+    U32
+  };
+  use crate::prim::{
+    U8Op,
+    U16Op,
+    U32Op,
+    I8Op,
+    I16Op,
+    I32Op,
+    I64Op,
+  };
+  use std::{
+    convert::TryInto,
+    mem
+  };
+  use num_bigint::BigUint;
   impl Arbitrary for U64Op {
     fn arbitrary(_g: &mut Gen) -> Self {
       let mut rng = rand::thread_rng();
-      let gen: u32 = rng.gen_range(0..35);
+      let gen: u32 = rng.gen_range(0..=33);
       match gen {
         0 => Self::Max,
         1 => Self::Min,
@@ -406,16 +439,16 @@ pub mod tests {
         23 => Self::ToU8,
         24 => Self::ToU16,
         25 => Self::ToU32,
-        26 => Self::ToU128,
-        27 => Self::ToNat,
-        28 => Self::ToI8,
-        29 => Self::ToI16,
-        30 => Self::ToI32,
-        31 => Self::ToI64,
-        32 => Self::ToI128,
-        33 => Self::ToInt,
-        34 => Self::ToBytes,
+        26 => Self::ToNat,
+        27 => Self::ToI8,
+        28 => Self::ToI16,
+        29 => Self::ToI32,
+        30 => Self::ToI64,
+        31 => Self::ToInt,
+        32 => Self::ToBytes,
         _ => Self::ToBits,
+        // 26 => Self::ToU128,
+        // 32 => Self::ToI128,
       }
     }
   }
@@ -425,6 +458,313 @@ pub mod tests {
     match U64Op::from_ipld(&x.to_ipld()) {
       Ok(y) => x == y,
       _ => false,
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply(
+    op: U64Op,
+    a: u64,
+    b: u64,
+    c: u32
+  ) -> TestResult {
+    let apply0_go = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        U64Op::apply0(op) ==
+        expected
+      )
+    };
+
+    let apply1_u64 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        U64Op::apply1(
+          op,
+          &U64(a)
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_u64_u64 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        U64Op::apply2(
+          op,
+          &U64(a),
+          &U64(b)
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_u64_u32 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        U64Op::apply2(
+          op,
+          &U64(a),
+          &U32(c)
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_u32_u64 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        U64Op::apply2(
+          op,
+          &U32(c),
+          &U64(a)
+        ) ==
+        expected
+      )
+    };
+
+    let from_bool = TestResult::from_bool;
+
+    match op {
+      U64Op::Max => apply0_go(Some(U64(u64::MAX))),
+      U64Op::Min => apply0_go(Some(U64(u64::MIN))),
+      U64Op::Eql => apply2_u64_u64(Some(Bool(a == b))),
+      U64Op::Lte => apply2_u64_u64(Some(Bool(a <= b))),
+      U64Op::Lth => apply2_u64_u64(Some(Bool(a < b))),
+      U64Op::Gth => apply2_u64_u64(Some(Bool(a > b))),
+      U64Op::Gte => apply2_u64_u64(Some(Bool(a >= b))),
+      U64Op::Not => apply1_u64(Some(U64(!a))),
+      U64Op::And => apply2_u64_u64(Some(U64(a & b))),
+      U64Op::Or => apply2_u64_u64(Some(U64(a | b))),
+      U64Op::Xor => apply2_u64_u64(Some(U64(a ^ b))),
+      U64Op::Add => apply2_u64_u64(Some(U64(a.wrapping_add(b)))),
+      U64Op::Sub => apply2_u64_u64(Some(U64(a.wrapping_sub(b)))),
+      U64Op::Mul => apply2_u64_u64(Some(U64(a.wrapping_mul(b)))),
+      U64Op::Div => apply2_u64_u64(
+        if b == 0 {
+          None
+        } else {
+          Some(U64(a.wrapping_div(b)))
+        }
+      ),
+      U64Op::Mod => apply2_u64_u64(
+        if b == 0 {
+          None
+        } else {
+          Some(U64(a.wrapping_rem(b)))
+        }
+      ),
+      U64Op::Pow => apply2_u64_u32(Some(U64(a.wrapping_pow(c)))),
+      U64Op::Shl => apply2_u32_u64(Some(U64(a.wrapping_shl(c)))),
+      U64Op::Shr => apply2_u32_u64(Some(U64(a.wrapping_shr(c)))),
+      U64Op::Rol => apply2_u32_u64(Some(U64(a.rotate_left(c)))),
+      U64Op::Ror => apply2_u32_u64(Some(U64(a.rotate_right(c)))),
+      U64Op::CountZeros => apply1_u64(Some(U32(a.count_zeros()))),
+      U64Op::CountOnes => apply1_u64(Some(U32(a.count_ones()))),
+      U64Op::ToU8 => from_bool(
+        if a > u8::MAX.into() {
+          U64Op::apply1(op, &U64(a)) == None
+        } else {
+          U8Op::apply1(
+            U8Op::ToU64,
+            &U64Op::apply1(op, &U64(a)).unwrap()
+          ) == Some(U64(a))
+        }
+      ),
+      U64Op::ToU16 => from_bool(
+        if a > u16::MAX.into() {
+          U64Op::apply1(op, &U64(a)) == None
+        } else {
+          U16Op::apply1(
+            U16Op::ToU64,
+            &U64Op::apply1(op, &U64(a)).unwrap()
+          ) == Some(U64(a))
+        }
+      ),
+      U64Op::ToU32 => from_bool(
+        if a > u32::MAX.into() {
+          U64Op::apply1(op, &U64(a)) == None
+        } else {
+          U32Op::apply1(
+            U32Op::ToU64,
+            &U64Op::apply1(op, &U64(a)).unwrap()
+          ) == Some(U64(a))
+        }
+      ),
+      U64Op::ToU128 => TestResult::discard(),
+      U64Op::ToNat => apply1_u64(Some(Nat(BigUint::from(a)))),
+      U64Op::ToI8 => from_bool(
+        if a > i8::MAX.try_into().unwrap() {
+          U64Op::apply1(op, &U64(a)) == None
+        } else {
+          I8Op::apply1(
+            I8Op::ToU64,
+            &U64Op::apply1(op, &U64(a)).unwrap()
+          ) == Some(U64(a))
+        }
+      ),
+      U64Op::ToI16 => from_bool(
+        if a > i16::MAX.try_into().unwrap() {
+          U64Op::apply1(op, &U64(a)) == None
+        } else {
+          I16Op::apply1(
+            I16Op::ToU64,
+            &U64Op::apply1(op, &U64(a)).unwrap()
+          ) == Some(U64(a))
+        }
+      ),
+      U64Op::ToI32 => from_bool(
+        if a > i32::MAX.try_into().unwrap() {
+          U64Op::apply1(op, &U64(a)) == None
+        } else {
+          I32Op::apply1(
+            I32Op::ToU64,
+            &U64Op::apply1(op, &U64(a)).unwrap()
+          ) == Some(U64(a))
+        }
+      ),
+      U64Op::ToI64 => from_bool(
+        if a > i64::MAX.try_into().unwrap() {
+          U64Op::apply1(op, &U64(a)) == None
+        } else {
+          I64Op::apply1(
+            I64Op::ToU64,
+            &U64Op::apply1(op, &U64(a)).unwrap()
+          ) == Some(U64(a))
+        }
+      ),
+      U64Op::ToI128 => TestResult::discard(),
+      U64Op::ToInt => apply1_u64(Some(Int(a.into()))),
+      U64Op::ToBits => apply1_u64(Some(Bits(bits::bytes_to_bits(64, &a.to_be_bytes().into())))),
+      U64Op::ToBytes => apply1_u64(Some(Bytes(a.to_be_bytes().into()))),
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply_none_on_invalid(
+    op: U64Op,
+    a: Literal,
+    b: u64,
+    c: u32,
+    test_arg_2: bool,
+  ) -> TestResult {
+    let test_apply1_none_on_invalid = |
+      valid_arg: Literal
+    | -> TestResult {
+      if mem::discriminant(&valid_arg) == mem::discriminant(&a) {
+        TestResult::discard()
+      } else {
+        TestResult::from_bool(
+          U64Op::apply1(
+            op,
+            &a
+          ) ==
+          None
+        )
+      }
+    };
+
+    let test_apply2_none_on_invalid = |
+      valid_arg: Literal,
+      a_: Literal,
+      b_: Literal
+    | -> TestResult {
+      let go = || TestResult::from_bool(
+        U64Op::apply2(
+          op,
+          &a_,
+          &b_
+        ) ==
+        None
+      );
+      if test_arg_2 {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&a_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      } else {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&b_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      }
+    };
+
+    match op {
+      // Arity 0.
+      U64Op::Max |
+      U64Op::Min => TestResult::discard(),
+      // Arity 1, valid is U64.
+      U64Op::Not |
+      U64Op::CountZeros |
+      U64Op::CountOnes |
+      U64Op::ToU8 |
+      U64Op::ToU16 |
+      U64Op::ToU32 |
+      U64Op::ToU128 |
+      U64Op::ToNat |
+      U64Op::ToI8 |
+      U64Op::ToI16 |
+      U64Op::ToI32 |
+      U64Op::ToI64 |
+      U64Op::ToI128 |
+      U64Op::ToInt |
+      U64Op::ToBytes |
+      U64Op::ToBits => test_apply1_none_on_invalid(U64(b)),
+      // Arity 2, valid are U64 on a and b.
+      U64Op::Eql |
+      U64Op::Lte |
+      U64Op::Lth |
+      U64Op::Gth |
+      U64Op::Gte |
+      U64Op::And |
+      U64Op::Or |
+      U64Op::Xor |
+      U64Op::Add |
+      U64Op::Sub |
+      U64Op::Mul |
+      U64Op::Div |
+      U64Op::Mod => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          U64(b),
+          a,
+          U64(b)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          U64(b),
+          U64(b),
+          a
+        )
+      },
+      // Arity 2, valid are U64 on a and U32 on b.
+      U64Op::Pow => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          U64(b),
+          a,
+          U32(c)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          U32(c),
+          U64(b),
+          a
+        )
+      },
+      // Arity 2, valid are U32 on a and U64 on b.
+      U64Op::Shl |
+      U64Op::Shr |
+      U64Op::Rol |
+      U64Op::Ror => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          U32(c),
+          a,
+          U64(b)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          U64(b),
+          U32(c),
+          a
+        )
+      }
     }
   }
 }

--- a/core/src/prim/u8.rs
+++ b/core/src/prim/u8.rs
@@ -13,6 +13,8 @@ use crate::{
   yatima,
 };
 
+use num_bigint::BigUint;
+
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum U8Op {
   Max,
@@ -49,8 +51,8 @@ pub enum U8Op {
   ToI64,
   ToI128,
   ToInt,
-  ToBytes,
   ToBits,
+  ToBytes,
   ToChar,
 }
 
@@ -328,6 +330,7 @@ impl U8Op {
       (Self::ToU32, U8(x)) => Some(U32((*x).into())),
       (Self::ToU64, U8(x)) => Some(U64((*x).into())),
       (Self::ToU128, U8(x)) => Some(U128((*x).into())),
+      (Self::ToNat, U8(x)) => Some(Nat(BigUint::from(u64::try_from(*x).unwrap()))),
       (Self::ToI8, U8(x)) => i8::try_from(*x).ok().map(I8),
       (Self::ToI16, U8(x)) => Some(I16((*x).into())),
       (Self::ToI32, U8(x)) => Some(I32((*x).into())),
@@ -335,10 +338,8 @@ impl U8Op {
       (Self::ToI128, U8(x)) => Some(I128((*x).into())),
       (Self::Not, U8(x)) => Some(U8(!x)),
       (Self::ToInt, U8(x)) => Some(Int((*x).into())),
+      (Self::ToBits, U8(x)) => Some(Bits(bits::bytes_to_bits(8, &x.to_be_bytes().into()))),
       (Self::ToBytes, U8(x)) => Some(Bytes(x.to_be_bytes().into())),
-      (Self::ToBits, U8(x)) => {
-        Some(Bits(bits::bytes_to_bits(8, &x.to_be_bytes().into())))
-      }
       _ => None,
     }
   }
@@ -357,8 +358,16 @@ impl U8Op {
       (Self::Add, U8(x), U8(y)) => Some(U8(x.wrapping_add(*y))),
       (Self::Sub, U8(x), U8(y)) => Some(U8(x.wrapping_sub(*y))),
       (Self::Mul, U8(x), U8(y)) => Some(U8(x.wrapping_mul(*y))),
-      (Self::Div, U8(x), U8(y)) => Some(U8(x.wrapping_div(*y))),
-      (Self::Mod, U8(x), U8(y)) => Some(U8(x.wrapping_rem(*y))),
+      (Self::Div, U8(x), U8(y)) => if *y == 0 {
+        None
+      } else {
+        Some(U8(x.wrapping_div(*y)))
+      },
+      (Self::Mod, U8(x), U8(y)) => if *y == 0 {
+        None
+      } else {
+        Some(U8(x.wrapping_rem(*y)))
+      },
       (Self::Pow, U8(x), U32(y)) => Some(U8(x.wrapping_pow(*y))),
       (Self::Shl, U32(x), U8(y)) => Some(U8(y.wrapping_shl(*x))),
       (Self::Shr, U32(x), U8(y)) => Some(U8(y.wrapping_shr(*x))),
@@ -381,12 +390,37 @@ pub mod tests {
   use quickcheck::{
     Arbitrary,
     Gen,
+    TestResult
   };
   use rand::Rng;
+  use Literal::{
+    U8,
+    Bool,
+    Nat,
+    Int,
+    Bits,
+    Bytes,
+    U32,
+    Char
+  };
+  use crate::prim::{
+    U16Op,
+    U32Op,
+    U64Op,
+    I8Op,
+    I16Op,
+    I32Op,
+    I64Op,
+  };
+  use std::{
+    convert::TryInto,
+    mem
+  };
+  use num_bigint::BigUint;
   impl Arbitrary for U8Op {
     fn arbitrary(_g: &mut Gen) -> Self {
       let mut rng = rand::thread_rng();
-      let gen: u32 = rng.gen_range(0..36);
+      let gen: u32 = rng.gen_range(0..=34);
       match gen {
         0 => Self::Max,
         1 => Self::Min,
@@ -415,16 +449,16 @@ pub mod tests {
         24 => Self::ToU16,
         25 => Self::ToU32,
         26 => Self::ToU64,
-        27 => Self::ToU128,
-        28 => Self::ToNat,
-        29 => Self::ToI8,
-        30 => Self::ToI16,
-        31 => Self::ToI32,
-        32 => Self::ToI64,
-        33 => Self::ToI128,
-        34 => Self::ToInt,
-        35 => Self::ToBytes,
+        27 => Self::ToNat,
+        28 => Self::ToI8,
+        29 => Self::ToI16,
+        30 => Self::ToI32,
+        31 => Self::ToI64,
+        32 => Self::ToInt,
+        33 => Self::ToBytes,
         _ => Self::ToBits,
+        // 27 => Self::ToU128,
+        // 33 => Self::ToI128,
       }
     }
   }
@@ -434,6 +468,291 @@ pub mod tests {
     match U8Op::from_ipld(&x.to_ipld()) {
       Ok(y) => x == y,
       _ => false,
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply(
+    op: U8Op,
+    a: u8,
+    b: u8,
+    c: u32
+  ) -> TestResult {
+    let apply0_go = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        U8Op::apply0(op) ==
+        expected
+      )
+    };
+
+    let apply1_u8 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        U8Op::apply1(
+          op,
+          &U8(a)
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_u8_u8 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        U8Op::apply2(
+          op,
+          &U8(a),
+          &U8(b)
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_u8_u32 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        U8Op::apply2(
+          op,
+          &U8(a),
+          &U32(c)
+        ) ==
+        expected
+      )
+    };
+
+    let apply2_u32_u8 = |expected: Option<Literal>| -> TestResult {
+      TestResult::from_bool(
+        U8Op::apply2(
+          op,
+          &U32(c),
+          &U8(a)
+        ) ==
+        expected
+      )
+    };
+
+    let from_bool = TestResult::from_bool;
+
+    match op {
+      U8Op::Max => apply0_go(Some(U8(u8::MAX))),
+      U8Op::Min => apply0_go(Some(U8(u8::MIN))),
+      U8Op::Eql => apply2_u8_u8(Some(Bool(a == b))),
+      U8Op::Lte => apply2_u8_u8(Some(Bool(a <= b))),
+      U8Op::Lth => apply2_u8_u8(Some(Bool(a < b))),
+      U8Op::Gth => apply2_u8_u8(Some(Bool(a > b))),
+      U8Op::Gte => apply2_u8_u8(Some(Bool(a >= b))),
+      U8Op::Not => apply1_u8(Some(U8(!a))),
+      U8Op::And => apply2_u8_u8(Some(U8(a & b))),
+      U8Op::Or => apply2_u8_u8(Some(U8(a | b))),
+      U8Op::Xor => apply2_u8_u8(Some(U8(a ^ b))),
+      U8Op::Add => apply2_u8_u8(Some(U8(a.wrapping_add(b)))),
+      U8Op::Sub => apply2_u8_u8(Some(U8(a.wrapping_sub(b)))),
+      U8Op::Mul => apply2_u8_u8(Some(U8(a.wrapping_mul(b)))),
+      U8Op::Div => apply2_u8_u8(
+        if b == 0 {
+          None
+        } else {
+          Some(U8(a.wrapping_div(b)))
+        }
+      ),
+      U8Op::Mod => apply2_u8_u8(
+        if b == 0 {
+          None
+        } else {
+          Some(U8(a.wrapping_rem(b)))
+        }
+      ),
+      U8Op::Pow => apply2_u8_u32(Some(U8(a.wrapping_pow(c)))),
+      U8Op::Shl => apply2_u32_u8(Some(U8(a.wrapping_shl(c)))),
+      U8Op::Shr => apply2_u32_u8(Some(U8(a.wrapping_shr(c)))),
+      U8Op::Rol => apply2_u32_u8(Some(U8(a.rotate_left(c)))),
+      U8Op::Ror => apply2_u32_u8(Some(U8(a.rotate_right(c)))),
+      U8Op::CountZeros => apply1_u8(Some(U32(a.count_zeros()))),
+      U8Op::CountOnes => apply1_u8(Some(U32(a.count_ones()))),
+      U8Op::ToU16 => from_bool(
+        U16Op::apply1(
+          U16Op::ToU8,
+          &U8Op::apply1(op, &U8(a)).unwrap()
+        ) == Some(U8(a))
+      ),
+      U8Op::ToU32 => from_bool(
+        U32Op::apply1(
+          U32Op::ToU8,
+          &U8Op::apply1(op, &U8(a)).unwrap()
+        ) == Some(U8(a))
+      ),
+      U8Op::ToU64 => from_bool(
+        U64Op::apply1(
+          U64Op::ToU8,
+          &U8Op::apply1(op, &U8(a)).unwrap()
+        ) == Some(U8(a))
+      ),
+      U8Op::ToU128 => TestResult::discard(),
+      U8Op::ToNat => apply1_u8(Some(Nat(BigUint::from(u64::try_from(a).unwrap())))),
+      U8Op::ToI8 => from_bool(
+        if a > i8::MAX.try_into().unwrap() {
+          U8Op::apply1(op, &U8(a)) == None
+        } else {
+          I8Op::apply1(
+            I8Op::ToU8,
+            &U8Op::apply1(op, &U8(a)).unwrap()
+          ) == Some(U8(a))
+        }
+      ),
+      U8Op::ToI16 => from_bool(
+        I16Op::apply1(
+          I16Op::ToU8,
+          &U8Op::apply1(op, &U8(a)).unwrap()
+        ) == Some(U8(a))
+      ),
+      U8Op::ToI32 => from_bool(
+        I32Op::apply1(
+          I32Op::ToU8,
+          &U8Op::apply1(op, &U8(a)).unwrap()
+        ) == Some(U8(a))
+      ),
+      U8Op::ToI64 => from_bool(
+        I64Op::apply1(
+          I64Op::ToU8,
+          &U8Op::apply1(op, &U8(a)).unwrap()
+        ) == Some(U8(a))
+      ),
+      U8Op::ToI128 => TestResult::discard(),
+      U8Op::ToInt => apply1_u8(Some(Int(a.into()))),
+      U8Op::ToBits => apply1_u8(Some(Bits(bits::bytes_to_bits(8, &a.to_be_bytes().into())))),
+      U8Op::ToBytes => apply1_u8(Some(Bytes(a.to_be_bytes().into()))),
+      U8Op::ToChar => apply1_u8(Some(Char((a).into()))),
+    }
+  }
+
+  #[quickcheck]
+  fn test_apply_none_on_invalid(
+    op: U8Op,
+    a: Literal,
+    b: u8,
+    c: u32,
+    test_arg_2: bool,
+  ) -> TestResult {
+    let test_apply1_none_on_invalid = |
+      valid_arg: Literal
+    | -> TestResult {
+      if mem::discriminant(&valid_arg) == mem::discriminant(&a) {
+        TestResult::discard()
+      } else {
+        TestResult::from_bool(
+          U8Op::apply1(
+            op,
+            &a
+          ) ==
+          None
+        )
+      }
+    };
+
+    let test_apply2_none_on_invalid = |
+      valid_arg: Literal,
+      a_: Literal,
+      b_: Literal
+    | -> TestResult {
+      let go = || TestResult::from_bool(
+        U8Op::apply2(
+          op,
+          &a_,
+          &b_
+        ) ==
+        None
+      );
+      if test_arg_2 {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&a_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      } else {
+        if mem::discriminant(&valid_arg) == mem::discriminant(&b_) {
+          TestResult::discard()
+        } else {
+          go()
+        }
+      }
+    };
+
+    match op {
+      // Arity 0.
+      U8Op::Max |
+      U8Op::Min => TestResult::discard(),
+      // Arity 1, valid is U8.
+      U8Op::Not |
+      U8Op::CountZeros |
+      U8Op::CountOnes |
+      U8Op::ToU16 |
+      U8Op::ToU32 |
+      U8Op::ToU64 |
+      U8Op::ToU128 |
+      U8Op::ToNat |
+      U8Op::ToI8 |
+      U8Op::ToI16 |
+      U8Op::ToI32 |
+      U8Op::ToI64 |
+      U8Op::ToI128 |
+      U8Op::ToInt |
+      U8Op::ToBytes |
+      U8Op::ToBits |
+      U8Op::ToChar => test_apply1_none_on_invalid(U8(b)),
+      // Arity 2, valid are U8 on a and b.
+      U8Op::Eql |
+      U8Op::Lte |
+      U8Op::Lth |
+      U8Op::Gth |
+      U8Op::Gte |
+      U8Op::And |
+      U8Op::Or |
+      U8Op::Xor |
+      U8Op::Add |
+      U8Op::Sub |
+      U8Op::Mul |
+      U8Op::Div |
+      U8Op::Mod => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          U8(b),
+          a,
+          U8(b)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          U8(b),
+          U8(b),
+          a
+        )
+      },
+      // Arity 2, valid are U8 on a and U32 on b.
+      U8Op::Pow => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          U8(b),
+          a,
+          U32(c)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          U32(c),
+          U8(b),
+          a
+        )
+      },
+      // Arity 2, valid are U32 on a and U8 on b.
+      U8Op::Shl |
+      U8Op::Shr |
+      U8Op::Rol |
+      U8Op::Ror => if test_arg_2 {
+        test_apply2_none_on_invalid(
+          U32(c),
+          a,
+          U8(b)
+        )
+      } else {
+        test_apply2_none_on_invalid(
+          U8(b),
+          U32(c),
+          a
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
Starting work towards #37 . Some of the tests are probably redundant and I'm not sure if it was a good idea to put the test cases in a vector which is iterated through because the error messages no longer show the line number of the failing test. I did add some messages to the assertion that should make it at least a little easier to track these failures down. Let me know if this was a bad idea and I'll change it such that each `assert_eq!` call is on its own line instead.