### PR TITLE
Ignore .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 result
 result-*
 .pre-commit-config.yaml
+/.vscode/


### PR DESCRIPTION
I have `"files.trimTrailingWhitespace": true` in my user configuration for VS Code, so I would like to turn it off in this repo by putting the following in `.vscode/settings.json`, to avoid things like https://github.com/yatima-inc/yatima/pull/71/commits/46770723d1302f81aa3ac97da3d35688bcefe2b2 in the future (see also #69):
```json
{
  "files.trimTrailingWhitespace": false
}
```
This PR adds the `.vscode/` directory to `.gitignore` so that different people can put their own configuration in that file without accidentally committing it.