### PR TITLE
Don't run duplicate CI on non-fork PRs

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -2,6 +2,8 @@ name: "Cargo CI"
 on:
   pull_request:
   push:
+    branches:
+      - main
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -2,6 +2,8 @@ name: "Nix CI"
 on:
   pull_request:
   push:
+    branches:
+      - main
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This restricts the `push` event so it only triggers CI on the `main` branch, eliminating the "double CI" that currently happens for PRs whose head branch is in the yatima-inc/yatima source repo rather than in a fork.

Example of double CI: https://github.com/yatima-inc/yatima/pull/61/commits/58a60ce8e0c142869157b088d2b8219b8ca6ba62

![double](https://user-images.githubusercontent.com/8246041/121276669-edc03600-c883-11eb-9215-54f2f8c445bb.PNG)