### PR TITLE
Fix compilation to Wasm instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,21 @@ nix-build default.nix
 ### Compiling to WASM
 
 ```bash
-wasm-pack build --target web
+nix-shell
+cd web
+wasm-pack build
 ```
 
-Host the experimental web version with:
+Then run the following command to install required dependencies:
 
 ```bash
-yatima hashspace server
+npm install
+```
+
+Afterwards, the experimental web version can be hosted with:
+
+```bash
+npm start
 ```
 
 ### With cargo


### PR DESCRIPTION
The current instructions don't seem to work, but these do.