### PR TITLE
Add unicode support to the web repl

### DIFF
--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -18,9 +18,9 @@ multiaddr = "*"
 sized-chunks = { git = "https://github.com/yatima-inc/sized-chunks", branch = "main", default-features = false }
 sp-cid = { git = "https://github.com/yatima-inc/sp-cid", branch = "main" }
 sp-ipld = { git = "https://github.com/yatima-inc/sp-ipld", branch = "main" }
+unicode-segmentation = "1.8.0"
 wasm-bindgen = { version = "0.2.72", features = ["serde-serialize"]  }
 wasm-bindgen-futures = "0.4.22"
-unicode-segmentation = "1.8.0"
 xterm-js-rs = { version = "0.1.1", features = ["xterm-addon-fit", "xterm-addon-search", "xterm-addon-web-links"] }
 yatima-core = { path = "../core" }
 yatima-utils = { path = "../utils" }

--- a/web/src/terminal_sequences.rs
+++ b/web/src/terminal_sequences.rs
@@ -1,22 +1,26 @@
 pub mod terminal_sequences {
   // Keyboard keys
+  pub const CTRL_C: &str = "\u{3}";
+  pub const CTRL_LEFT: &str = "\u{1B}[1;5D";
+  pub const CTRL_L: &str = "\u{C}";
+  pub const CTRL_RIGHT: &str = "\u{1B}[1;5C";
+  pub const DOWN: &str = "\u{1B}[B";
+  pub const DELETE: &str = "\u{1B}[3~";
+  pub const END: &str = "\u{1B}[F";
+  pub const HOME: &str = "\u{1B}[H";
   pub const INSERT: &str = "\u{1B}[2~";
   pub const LEFT: &str = "\u{1B}[D";
   pub const RIGHT: &str = "\u{1B}[C";
   pub const UP: &str = "\u{1B}[A";
-  pub const DOWN: &str = "\u{1B}[B";
-  pub const DELETE: &str = "\u{1B}[3~";
-  pub const HOME: &str = "\u{1B}[H";
-  pub const END: &str = "\u{1B}[F";
-  pub const PG_UP: &str = "\u{1B}[5~";
-  pub const PG_DOWN: &str = "\u{1B}[6~";
+  pub const PAGE_UP: &str = "\u{1B}[5~";
+  pub const PAGE_DOWN: &str = "\u{1B}[6~";
 
   // xterm.js Terminal Sequences
   // See https://xtermjs.org/docs/api/vtfeatures/ for missing documentation (`SP` is ` `)
   // See https://vt100.net/docs/vt510-rm/chapter4.html for more information on terminal sequences
   // See https://notes.burke.libbey.me/ansi-escape-codes/ for more information on terminal sequences
 
-  // Constant sequences (no parameters ``ps``, `Pm` or `Pt`)
+  // Constant sequences (no parameters `Ps`, `Pm` or `Pt`)
   // C0
   /// NUL is ignored.
   pub const NUL: &str = "\u{00}";


### PR DESCRIPTION
Tasks:
* [x] Implement key (combinations):
	* [x] Delete
	* [x] Home
	* [x] End
	* [x] Ctrl-Left
	* [x] Ctrl-Right
	* [x] Ctrl-C
	* [x] Ctrl-L 
* [x] Fix bug where backspacing/deleting a `\t` on the first tab stop doesn't move the cursor and characters on the terminal the appropriate amount.
* [x] Fix bug preventing Ctrl-Right from working on the last word of a line.
* [x] Add handling of tab graphemes in handling of left, right, ^left, ^right, home, end, delete and backspace keys.
* [ ] Add handling of newline graphemes in handling of left, right, ^left, ^right, home, end, delete and backspace keys.
* [ ] Handle other keys/combinations:
	* [x] Tab: Insert a tab grapheme (should re-enable this when tab support in other keys is fixed).
	* [ ] Insert: Toggle insert/replace mode.
* [ ] Multi-line support.
* [ ] Fix deleting/backspacing/moving across wrapped/reflowed lines.
* [ ] Add tests.