### PR TITLE
Hashing the typechecker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /build
 /lake-packages
-*.yenv
+*.env
 *.ldstore
 *.lurk
 *.frames

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 /build
 /lake-packages
 *.yenv
-*.store
+*.ldstore
 *.lurk
 *.frames
-*.json
-!lake-manifest.json

--- a/TestsUtils/ContAddrAndExtractTests.lean
+++ b/TestsUtils/ContAddrAndExtractTests.lean
@@ -24,7 +24,7 @@ def ensembleTestExtractors (source : FilePath)
   let leanEnv ← Lean.runFrontend (← IO.FS.readFile source) source
   let (constMap, delta) := leanEnv.getConstsAndDelta
   withExceptOkM s!"Content-addresses {source}"
-      (← contAddr constMap delta default true false) fun stt => do
+      (← contAddr constMap delta true false) fun stt => do
     let pureTests := extractors.foldl (init := .done)
       fun acc ext => acc ++ (ext stt)
     ioExtractors.foldlM (init := pureTests) fun acc ext =>

--- a/Yatima/Cli/ContAddrCmd.lean
+++ b/Yatima/Cli/ContAddrCmd.lean
@@ -6,7 +6,7 @@ def defaultEnv : String :=
   "out.yenv"
 
 def defaultStore : String :=
-  "out.store"
+  "out.ldstore"
 
 open Yatima.ContAddr in
 def contAddrRun (p : Cli.Parsed) : IO UInt32 := do

--- a/Yatima/Cli/ContAddrCmd.lean
+++ b/Yatima/Cli/ContAddrCmd.lean
@@ -3,7 +3,7 @@ import Yatima.Cli.Utils
 import Yatima.ContAddr.ContAddr
 
 def defaultEnv : String :=
-  "out.yenv"
+  "out.env"
 
 open Yatima.ContAddr in
 def contAddrRun (p : Cli.Parsed) : IO UInt32 := do

--- a/Yatima/Cli/ContAddrCmd.lean
+++ b/Yatima/Cli/ContAddrCmd.lean
@@ -15,13 +15,6 @@ def contAddrRun (p : Cli.Parsed) : IO UInt32 := do
   let some source := p.positionalArg? "source" |>.map (·.value)
     | IO.eprintln "No source was provided"; return 1
 
-  -- Load input environment
-  let env ← match p.flag? "input" |>.map (·.value) with
-    | none => pure default
-    | some envFileName => match ← loadData envFileName false with
-      | none => return 1
-      | some env => pure env
-
   -- Run Lean frontend
   let mut cronos ← Cronos.new.clock "Run Lean frontend"
   Lean.setLibsPaths
@@ -30,16 +23,15 @@ def contAddrRun (p : Cli.Parsed) : IO UInt32 := do
   let (constMap, delta) := leanEnv.getConstsAndDelta
   cronos ← cronos.clock! "Run Lean frontend"
 
-  let envFileName   := p.flag? "output" |>.map (·.value) |>.getD defaultEnv
-
   -- Start content-addressing
   cronos ← cronos.clock "Content-address"
-  let stt ← match ← contAddr constMap delta env false true with
+  let stt ← match ← contAddr constMap delta false true with
     | .error err => IO.eprintln err; return 1
     | .ok stt => pure stt
   cronos ← cronos.clock! "Content-address"
 
   -- dump the env
+  let envFileName := p.flag? "env" |>.map (·.value) |>.getD defaultEnv
   dumpData stt.env ⟨envFileName⟩  
 
   return 0
@@ -49,8 +41,7 @@ def contAddrCmd : Cli.Cmd := `[Cli|
   "Content-addresses Lean 4 code to Yatima IR"
 
   FLAGS:
-    i, "input"  : String;   "Optional input environment file used as cache"
-    o, "output" : String; s!"Output environment file. Defaults to '{defaultEnv}'"
+    e, "env" : String; s!"Output environment file. Defaults to '{defaultEnv}'"
 
   ARGS:
     source : String; "Lean source file"

--- a/Yatima/Cli/GenTypecheckerCmd.lean
+++ b/Yatima/Cli/GenTypecheckerCmd.lean
@@ -19,6 +19,7 @@ def genTypecheckerRun (_p : Cli.Parsed) : IO UInt32 := do
   IO.FS.createDirAll STOREDIR
   dumpData stt LDONHASHCACHE
   dumpData hash TCHASH
+  IO.println s!"Typechecker hash: {hash.asHex}"
   return 0
 
 def genTypecheckerCmd : Cli.Cmd := `[Cli|

--- a/Yatima/Cli/GenTypecheckerCmd.lean
+++ b/Yatima/Cli/GenTypecheckerCmd.lean
@@ -2,6 +2,7 @@ import Cli.Basic
 import Yatima.Lean.Utils
 import Yatima.CodeGen.CodeGen
 import Yatima.Common.IO
+import Yatima.Common.LightData
 import Yatima.Typechecker.Typechecker -- forcing oleans generation
 
 def tcCode : String :=
@@ -12,11 +13,12 @@ open Yatima.CodeGen in
 def genTypecheckerRun (_p : Cli.Parsed) : IO UInt32 := do
   Lean.setLibsPaths
   let expr ← match codeGen (← Lean.runFrontend tcCode default) "tc" with
-  | .error msg => IO.eprintln msg; return 1
-  | .ok expr => pure expr
+    | .error msg => IO.eprintln msg; return 1
+    | .ok expr => pure expr
+  let (hash, stt) := expr.anon.toLDON.commit default
   IO.FS.createDirAll STOREDIR
-  IO.FS.writeFile LURKTCPATH (expr.toString true)
-  IO.FS.writeFile LURKTCANONPATH (expr.anon.toString true)
+  dumpData stt LDONHASHCACHE
+  dumpData hash TCHASH
   return 0
 
 def genTypecheckerCmd : Cli.Cmd := `[Cli|

--- a/Yatima/Cli/PinCmd.lean
+++ b/Yatima/Cli/PinCmd.lean
@@ -52,11 +52,11 @@ def pinRun (_p : Cli.Parsed) : IO UInt32 := do
   let leanEnv ← Lean.runFrontend primsInput default
   let (constMap, delta) := leanEnv.getConstsAndDelta
 
-  let commits ← match ← contAddr constMap delta default false false with
+  let commits ← match ← contAddr constMap default false false with
     | .error err => IO.eprintln err; return 1
     | .ok stt => pure $ stt.env.consts.toList
 
-  let commitsQuick ← match ← contAddr constMap delta default true false with
+  let commitsQuick ← match ← contAddr constMap delta true false with
     | .error err => IO.eprintln err; return 1
     | .ok stt => pure $ stt.env.consts.toList
 

--- a/Yatima/Cli/TypecheckCmd.lean
+++ b/Yatima/Cli/TypecheckCmd.lean
@@ -24,7 +24,7 @@ def typecheckRun (p : Cli.Parsed) : IO UInt32 := do
 
   -- Start content-addressing
   cronos ← cronos.clock "Content-address"
-  let stt ← match ← contAddr constMap delta default true false with
+  let stt ← match ← contAddr constMap delta true false with
     | .error err => IO.eprintln err; return 1
     | .ok stt => pure stt
   cronos ← cronos.clock! "Content-address"

--- a/Yatima/Common/IO.lean
+++ b/Yatima/Common/IO.lean
@@ -34,16 +34,8 @@ initialize STOREDIR : FilePath ← do
   | some path => return path / ".yatima"
   | none => throw $ IO.userError "can't find home folder"
 
-initialize LURKDIR : FilePath ← do
-  match ← IO.getEnv "HOME" with
-  | some path => return path / ".lurk"
-  | none => throw $ IO.userError "can't find home folder"
-
-def LURKTCPATH : FilePath :=
-  STOREDIR / "tc.lurk"
-
-def LURKTCANONPATH : FilePath :=
-  STOREDIR / "tc_anon.lurk"
+def TCHASH : FilePath :=
+  STOREDIR / "tc_hash"
 
 def LDONHASHCACHE : FilePath :=
   STOREDIR / "ldon_hash_cache"

--- a/Yatima/Common/LightData.lean
+++ b/Yatima/Common/LightData.lean
@@ -219,14 +219,16 @@ instance : Encodable ScalarExpr LightData where
 
 def LDONToLightData : LDON → LightData
   | .nil => false
-  | .num x => .cell #[false, x]
-  | .str x => .cell #[true,  x]
+  | .sym x => .cell #[.atom ⟨#[ ]⟩, x] -- the most frequent
+  | .num x => .cell #[.cell  #[ ] , x]
+  | .str x => .cell #[.atom ⟨#[0]⟩, x] -- the least frequent
   | .cons x y => .cell #[false, LDONToLightData x, LDONToLightData y]
 
 partial def lightDataToLDON : LightData → Except String LDON
   | false => return .nil
-  | .cell #[false, x] => return .num (← dec x)
-  | .cell #[true,  x] => return .str (← dec x)
+  | .cell #[.atom ⟨#[ ]⟩, x] => return .sym (← dec x)
+  | .cell #[.cell  #[ ] , x] => return .num (← dec x)
+  | .cell #[.atom ⟨#[0]⟩, x] => return .str (← dec x)
   | .cell #[false, x, y] => return .cons (← lightDataToLDON x) (← lightDataToLDON y)
   | x => throw s!"Invalid encoding for LDON: {x}"
 
@@ -239,9 +241,9 @@ instance : Encodable Char LightData where
   decode x := return .ofNat (← dec x)
 
 instance : Encodable LDONHashState LightData where
-  encode | ⟨a, b, c⟩ => .cell #[a, b, c]
+  encode | ⟨a, b, c, d⟩ => .cell #[a, b, c, d]
   decode
-    | .cell #[a, b, c] => return ⟨← dec a, ← dec b, ← dec c⟩
+    | .cell #[a, b, c, d] => return ⟨← dec a, ← dec b, ← dec c, ← dec d⟩
     | x => throw s!"Invalid encoding for LDONHashState: {x}"
 
 end LDON

--- a/Yatima/Common/LightData.lean
+++ b/Yatima/Common/LightData.lean
@@ -241,9 +241,9 @@ instance : Encodable Char LightData where
   decode x := return .ofNat (← dec x)
 
 instance : Encodable LDONHashState LightData where
-  encode | ⟨a, b, c, d⟩ => .cell #[a, b, c, d]
+  encode | ⟨a, b, c⟩ => .cell #[a, b, c]
   decode
-    | .cell #[a, b, c, d] => return ⟨← dec a, ← dec b, ← dec c, ← dec d⟩
+    | .cell #[a, b, c] => return ⟨← dec a, ← dec b, ← dec c⟩
     | x => throw s!"Invalid encoding for LDONHashState: {x}"
 
 end LDON

--- a/Yatima/Common/LightData.lean
+++ b/Yatima/Common/LightData.lean
@@ -219,26 +219,26 @@ instance : Encodable ScalarExpr LightData where
 
 def LDONToLightData : LDON → LightData
   | .nil => false
-  | .sym x => .cell #[.atom ⟨#[ ]⟩, x] -- the most frequent
-  | .num x => .cell #[.cell  #[ ] , x]
-  | .str x => .cell #[.atom ⟨#[0]⟩, x] -- the least frequent
+  | .sym  x => .cell #[.atom ⟨#[ ]⟩, x] -- the most frequent
+  | .num  x => .cell #[.cell  #[ ] , x]
+  | .str  x => .cell #[.atom ⟨#[0]⟩, x]
+  | .char x => .cell #[.atom ⟨#[1]⟩, x]
+  | .u64  x => .cell #[.atom ⟨#[2]⟩, x]
   | .cons x y => .cell #[false, LDONToLightData x, LDONToLightData y]
 
 partial def lightDataToLDON : LightData → Except String LDON
   | false => return .nil
-  | .cell #[.atom ⟨#[ ]⟩, x] => return .sym (← dec x)
-  | .cell #[.cell  #[ ] , x] => return .num (← dec x)
-  | .cell #[.atom ⟨#[0]⟩, x] => return .str (← dec x)
+  | .cell #[.atom ⟨#[ ]⟩, x] => return .sym  (← dec x)
+  | .cell #[.cell  #[ ] , x] => return .num  (← dec x)
+  | .cell #[.atom ⟨#[0]⟩, x] => return .str  (← dec x)
+  | .cell #[.atom ⟨#[1]⟩, x] => return .char (← dec x)
+  | .cell #[.atom ⟨#[2]⟩, x] => return .u64  (← dec x)
   | .cell #[false, x, y] => return .cons (← lightDataToLDON x) (← lightDataToLDON y)
   | x => throw s!"Invalid encoding for LDON: {x}"
 
 instance : Encodable LDON LightData where
   encode := LDONToLightData
   decode := lightDataToLDON
-
-instance : Encodable Char LightData where
-  encode x := x.toNat
-  decode x := return .ofNat (← dec x)
 
 instance : Encodable LDONHashState LightData where
   encode | ⟨a, b, c⟩ => .cell #[a, b, c]

--- a/Yatima/ContAddr/ContAddr.lean
+++ b/Yatima/ContAddr/ContAddr.lean
@@ -465,7 +465,7 @@ def contAddr (constMap : Lean.ConstMap) (delta : List Lean.ConstantInfo)
     else pure $ (← loadData LDONHASHCACHE).getD default
   if persist then IO.FS.createDirAll STOREDIR
   match ← StateT.run (ReaderT.run (contAddrM delta)
-    (.init constMap quick persist)) (.init default ldonHashState) with
+    (.init constMap quick persist)) (.init ldonHashState) with
   | (.ok _, stt) => return .ok stt
   | (.error e, _) => return .error e
 

--- a/Yatima/ContAddr/ContAddr.lean
+++ b/Yatima/ContAddr/ContAddr.lean
@@ -457,7 +457,7 @@ Important: constants with open references in their expressions are filtered out.
 Open references are variables that point to names which aren't present in the
 `Lean.ConstMap`.
 -/
-def contAddr (constMap : Lean.ConstMap) (delta : List Lean.ConstantInfo) (yenv : Env)
+def contAddr (constMap : Lean.ConstMap) (delta : List Lean.ConstantInfo)
     (quick persist : Bool) : IO $ Except ContAddrError ContAddrState := do
   let persist := if quick then false else persist
   let ldonHashState ←
@@ -465,7 +465,7 @@ def contAddr (constMap : Lean.ConstMap) (delta : List Lean.ConstantInfo) (yenv :
     else pure $ (← loadData LDONHASHCACHE).getD default
   if persist then IO.FS.createDirAll STOREDIR
   match ← StateT.run (ReaderT.run (contAddrM delta)
-    (.init constMap quick persist)) (.init yenv ldonHashState) with
+    (.init constMap quick persist)) (.init default ldonHashState) with
   | (.ok _, stt) => return .ok stt
   | (.error e, _) => return .error e
 

--- a/Yatima/ContAddr/ContAddrM.lean
+++ b/Yatima/ContAddr/ContAddrM.lean
@@ -14,8 +14,8 @@ structure ContAddrState where
   ldonHashState : Lurk.LDONHashState -- to speed up committing
   deriving Inhabited
 
-def ContAddrState.init (env : Env) (ldonHashState : Lurk.LDONHashState) : ContAddrState :=
-  ⟨env, default, ldonHashState⟩
+def ContAddrState.init (ldonHashState : Lurk.LDONHashState) : ContAddrState :=
+  ⟨default, default, ldonHashState⟩
 
 def ContAddrState.store (stt : ContAddrState) : Std.RBMap Lurk.F Const compare :=
   stt.commits.foldl (init := .empty) fun acc c f => acc.insert f c

--- a/Yatima/Datatypes/Lurk.lean
+++ b/Yatima/Datatypes/Lurk.lean
@@ -1,4 +1,4 @@
-import Lurk.Field
+import Lurk.Backend.Expr
 import Poseidon.ForLurk
 import Std.Data.RBMap
 
@@ -181,5 +181,12 @@ def LDONHashState.extractComms (stt : LDONHashState) (comms : Array F) :
   match StateT.run (ReaderT.run (loadComms comms) ⟨stt.store, default⟩) default with
   | (.ok _, store) => return store
   | (.error e, _) => throw e
+
+namespace Backend.Expr
+
+def toLDON : Expr → LDON
+  | _ => sorry
+
+end Backend.Expr
 
 end Lurk

--- a/Yatima/Datatypes/Lurk.lean
+++ b/Yatima/Datatypes/Lurk.lean
@@ -9,23 +9,26 @@ namespace Lurk
 inductive LDON
   | nil
   | num : F → LDON
+  | u64 : UInt64 → LDON
+  | char : Char → LDON
   | str : String → LDON
   | sym : String → LDON
   | cons : LDON → LDON → LDON
   deriving Inhabited, Ord
 
 inductive Tag
-  | nil | cons | sym | num | str | char | comm
+  | nil | cons | sym | num | str | char | comm | u64
   deriving Ord, Repr
 
 def Tag.toF : Tag → F
-  | .nil   => .ofNat 0
-  | .cons  => .ofNat 1
-  | .sym   => .ofNat 2
-  | .num   => .ofNat 4
-  | .str   => .ofNat 6
-  | .char  => .ofNat 7
-  | .comm  => .ofNat 8
+  | .nil  => .ofNat 0
+  | .cons => .ofNat 1
+  | .sym  => .ofNat 2
+  | .num  => .ofNat 4
+  | .str  => .ofNat 6
+  | .char => .ofNat 7
+  | .comm => .ofNat 8
+  | .u64  => .ofNat 9
 
 def Tag.ofF : F → Option Tag
   | .ofNat 0 => return .nil
@@ -35,6 +38,7 @@ def Tag.ofF : F → Option Tag
   | .ofNat 6 => return .str
   | .ofNat 7 => return .char
   | .ofNat 8 => return .comm
+  | .ofNat 9 => return .u64
   | _ => none
 
 structure ScalarPtr where
@@ -43,7 +47,7 @@ structure ScalarPtr where
   deriving Ord, Repr
 
 @[inline] def ScalarPtr.isImmediate (ptr : ScalarPtr) : Bool :=
-  ptr matches ⟨.num, _⟩ | ⟨.char, _⟩ | ⟨.str, F.zero⟩ | ⟨.sym, F.zero⟩
+  ptr matches ⟨.num, _⟩ | ⟨.u64, _⟩| ⟨.char, _⟩ | ⟨.str, F.zero⟩ | ⟨.sym, F.zero⟩
 
 inductive ScalarExpr
   | cons : ScalarPtr → ScalarPtr → ScalarExpr
@@ -96,10 +100,9 @@ def hashChars (cs : List Char) : HashM ScalarPtr := do
   | some ptr => pure ptr
   | none =>
     let ptr ← match cs with
-      | [] => addExprHash ⟨.str, F.zero⟩ .strNil
+      | [] => pure ⟨.str, F.zero⟩
       | c :: cs =>
-        let n := .ofNat c.toNat
-        let headPtr ← addExprHash ⟨.char, n⟩ (.char n)
+        let headPtr := ⟨.char, .ofNat c.toNat⟩
         let tailPtr ← hashChars cs
         addExprHash ⟨.str, hashPtrPair headPtr tailPtr⟩ (.strCons headPtr tailPtr)
     modifyGet fun stt =>
@@ -116,12 +119,14 @@ def hashLDON (x : LDON) : HashM ScalarPtr := do
   | none =>
     let ptr ← match x with
       | .nil =>
-        let rootPtr ← addExprHash ⟨.sym, F.zero⟩ .symNil
+        let rootPtr := ⟨.sym, F.zero⟩
         let nilPtr  ← hashChars ['N', 'I', 'L']
         let lurkPtr ← hashChars ['L', 'U', 'R', 'K']
         let symPtr1 ← addExprHash ⟨.sym, hashPtrPair lurkPtr rootPtr⟩ (.symCons lurkPtr rootPtr)
         addExprHash ⟨.nil, hashPtrPair nilPtr symPtr1⟩ (.symCons nilPtr symPtr1)
-      | .num n => let n := .ofNat n; addExprHash ⟨.num, n⟩ (.num n)
+      | .num n => pure ⟨.num, n⟩
+      | .u64 n => pure ⟨.u64, .ofNat n.val⟩
+      | .char n => pure ⟨.char, .ofNat n.toNat⟩
       | .str s => hashChars s.data
       | .sym s => hashStrings [s, "LURK"]
       | .cons car cdr =>
@@ -178,8 +183,51 @@ def LDONHashState.extractComms (stt : LDONHashState) (comms : Array F) :
 
 namespace Backend.Expr
 
-def toLDON : Expr → LDON
-  | _ => sorry
+def datumToLDON : Datum → LDON
+  | .num  x => .num x
+  | .u64  x => .u64 x
+  | .char x => .char x
+  | .str  x => .str x
+  | .sym "NIL" => .nil
+  | .sym  x => .sym x
+  | .cons x y => .cons (datumToLDON x) (datumToLDON y)
+
+def atomToLDON : Atom → LDON
+  | .nil => .nil
+  | .t => .sym "T"
+  | .num x => .num x
+  | .u64 x => .u64 x
+  | .str x => .str x
+  | .char x => .char x
+
+partial def toLDON : Expr → LDON
+  | .atom a => atomToLDON a
+  | .sym s => .sym s
+  | .env => .cons (.sym "CURRENT-ENV") .nil
+  | .op₁ o e => .cons (.sym o.toString) (.cons e.toLDON .nil)
+  | .op₂ o e₁ e₂ => .cons (.sym o.toString) $ .cons e₁.toLDON $ .cons e₂.toLDON .nil
+  | e@(.begin ..) =>
+    .cons (.sym "BEGIN") $ e.telescopeBegin.foldr (.cons ·.toLDON ·) .nil
+  | .if a b c => .cons (.sym "IF") $ .cons a.toLDON $ .cons b.toLDON $ .cons c.toLDON .nil
+  | .app₀ e => .cons e.toLDON .nil
+  | .app f a => .cons f.toLDON (.cons a.toLDON .nil)
+  | .lambda s e =>
+    let (ss, b) := e.telescopeLam #[s]
+    .cons (.sym "LAMBDA") $
+      .cons (ss.foldr (fun s acc => .cons (.sym s) acc) .nil) $ .cons b.toLDON .nil
+  | .let s v b =>
+    let (bs, b) := b.telescopeLet #[(s, v)]
+    .cons (.sym "LET") $
+      .cons (bs.foldr (fun (s, v) acc =>
+          .cons (.cons (.sym s) (.cons v.toLDON .nil)) acc) .nil) $
+        .cons b.toLDON .nil
+  | .letrec s v b =>
+    let (bs, b) := b.telescopeLet #[(s, v)]
+    .cons (.sym "LETREC") $
+      .cons (bs.foldr (fun (s, v) acc =>
+          .cons (.cons (.sym s) (.cons v.toLDON .nil)) acc) .nil) $
+        .cons b.toLDON .nil
+  | .quote d => .cons (.sym "QUOTE") $ .cons (datumToLDON d) .nil
 
 end Backend.Expr
 

--- a/Yatima/Datatypes/Lurk.lean
+++ b/Yatima/Datatypes/Lurk.lean
@@ -69,10 +69,9 @@ def Store.get? (store : Store) : ScalarPtr → Option (Option ScalarExpr)
   | ptr => store.find? ptr
 
 structure LDONHashState where
-  store        : Store
-  charsCache   : RBMap (List Char)   ScalarPtr compare
-  stringsCache : RBMap (List String) ScalarPtr compare
-  ldonCache    : RBMap LDON          ScalarPtr compare
+  store      : Store
+  charsCache : RBMap (List Char) ScalarPtr compare
+  ldonCache  : RBMap LDON        ScalarPtr compare
   deriving Inhabited
 
 @[inline] def LDONHashState.get? (stt : LDONHashState) (ptr : ScalarPtr) :
@@ -106,15 +105,10 @@ def hashChars (cs : List Char) : HashM ScalarPtr := do
     modifyGet fun stt =>
       (ptr, { stt with charsCache := stt.charsCache.insert cs ptr })
 
-def hashStrings (ss : List String) : HashM ScalarPtr := do
-  match (← get).stringsCache.find? ss with
-  | some ptr => pure ptr
-  | none =>
-    let ptr ← ss.foldrM (init := ⟨.sym, F.zero⟩) fun s acc => do
-      let strPtr ← hashChars s.data
-      addExprHash ⟨.sym, hashPtrPair strPtr acc⟩ (.symCons strPtr acc)
-    modifyGet fun stt =>
-      (ptr, { stt with stringsCache := stt.stringsCache.insert ss ptr })
+def hashStrings (ss : List String) : HashM ScalarPtr :=
+  ss.foldrM (init := ⟨.sym, F.zero⟩) fun s acc => do
+    let strPtr ← hashChars s.data
+    addExprHash ⟨.sym, hashPtrPair strPtr acc⟩ (.symCons strPtr acc)
 
 def hashLDON (x : LDON) : HashM ScalarPtr := do
   match (← get).ldonCache.find? x with

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -46,9 +46,9 @@
   {"git":
    {"url": "https://github.com/yatima-inc/LightData",
     "subDir?": null,
-    "rev": "8be50d34c81f2b126656fb97636af2f5eace1cd3",
+    "rev": "7492abeae41f3a469396c73e13f48cd2b8da4a02",
     "name": "LightData",
-    "inputRev?": "8be50d34c81f2b126656fb97636af2f5eace1cd3"}},
+    "inputRev?": "7492abeae41f3a469396c73e13f48cd2b8da4a02"}},
   {"git":
    {"url": "https://github.com/leanprover/std4/",
     "subDir?": null,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -24,7 +24,7 @@ require Lurk from git
   "https://github.com/yatima-inc/Lurk.lean" @ "08f710e8958261a1730ace37b973706788f5a857"
 
 require LightData from git
-  "https://github.com/yatima-inc/LightData" @ "8be50d34c81f2b126656fb97636af2f5eace1cd3"
+  "https://github.com/yatima-inc/LightData" @ "7492abeae41f3a469396c73e13f48cd2b8da4a02"
 
 require std from git
   "https://github.com/leanprover/std4/" @ "fde95b16907bf38ea3f310af406868fc6bcf48d1"


### PR DESCRIPTION
This PR implements the changes needed to hash the typechecker. So the Lurk code to create proofs of typechecking are modified from this:
```lisp
(<typechecker code, which is a lambda> <constant hash>)
```
To this:
```lisp
((eval (open <typechecker hash>)) <constant hash>)
```
`eval` is needed because the typechecker is hashed as a datum.

This PR also removes a potential bug from a double layer of caching, when a cached env has the hash of a constant but the LDON store would not.